### PR TITLE
Replace top-app-bar internal CSS class getters with methods

### DIFF
--- a/packages/top-app-bar-fixed/src/top-app-bar-fixed-base.ts
+++ b/packages/top-app-bar-fixed/src/top-app-bar-fixed-base.ts
@@ -23,9 +23,9 @@ export class TopAppBarFixedBase extends TopAppBarBase {
 
   protected mdcFoundationClass = MDCFixedTopAppBarFoundation;
 
-  protected get barClasses() {
+  protected barClasses() {
     return {
-      ...super.barClasses,
+      ...super.barClasses(),
       'mdc-top-app-bar--fixed': true,
     };
   }

--- a/packages/top-app-bar-short/src/top-app-bar-short-base.ts
+++ b/packages/top-app-bar-short/src/top-app-bar-short-base.ts
@@ -30,13 +30,13 @@ export class TopAppBarShortBase extends TopAppBarBaseBase {
   })
   alwaysCollapsed = false;
 
-  protected get barClasses() {
+  protected barClasses() {
     return {
       'mdc-top-app-bar--short': true,
     };
   }
 
-  protected get contentClasses() {
+  protected contentClasses() {
     return {'mdc-top-app-bar--short-fixed-adjust': true};
   }
 

--- a/packages/top-app-bar/src/mwc-top-app-bar-base-base.ts
+++ b/packages/top-app-bar/src/mwc-top-app-bar-base-base.ts
@@ -67,12 +67,12 @@ export abstract class TopAppBarBaseBase extends BaseElement {
   /**
    * classMap map for classes on the bar
    */
-  protected abstract barClasses: ClassInfo;
+  protected abstract barClasses(): ClassInfo;
 
   /**
    * classMap map for classes on the content slot
    */
-  protected abstract contentClasses: ClassInfo;
+  protected abstract contentClasses(): ClassInfo;
 
   protected render() {
     // clang-format off
@@ -82,7 +82,7 @@ export abstract class TopAppBarBaseBase extends BaseElement {
     }
     // clang-format on
     return html`
-      <header class="mdc-top-app-bar ${classMap(this.barClasses)}">
+      <header class="mdc-top-app-bar ${classMap(this.barClasses())}">
       <div class="mdc-top-app-bar__row">
         <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start" id="navigation">
           <slot name="navigationIcon"
@@ -95,7 +95,7 @@ export abstract class TopAppBarBaseBase extends BaseElement {
         </section>
       </div>
     </header>
-    <div class="${classMap(this.contentClasses)}">
+    <div class="${classMap(this.contentClasses())}">
       <slot></slot>
     </div>
     `;

--- a/packages/top-app-bar/src/mwc-top-app-bar-base.ts
+++ b/packages/top-app-bar/src/mwc-top-app-bar-base.ts
@@ -31,14 +31,14 @@ export class TopAppBarBase extends TopAppBarBaseBase {
     this.mdcFoundation.handleWindowResize();
   };
 
-  protected get barClasses() {
+  protected barClasses() {
     return {
       'mdc-top-app-bar--dense': this.dense,
       'mdc-top-app-bar--prominent': this.prominent,
     };
   }
 
-  protected get contentClasses() {
+  protected contentClasses() {
     return {
       'mdc-top-app-bar--fixed-adjust': !this.dense && !this.prominent,
       'mdc-top-app-bar--dense-fixed-adjust': this.dense && !this.prominent,


### PR DESCRIPTION
We can never call superclass getters, becuase TypeScript doesn't allow that when transpiled to ES5. See https://github.com/Microsoft/TypeScript/issues/338. In this case, we can just define methods instead of getters.