### PR TITLE
Fix top-app-bar title centering for multiple action icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   ([#367](https://github.com/material-components/material-components-web-components/issues/367)).
 - Removed:
   - mwc-top-app-bar-short has been removed after guidance from the Material Design team.
+- Fix top-app-bar centering for multiple icons.
 
 ## [0.6.0] - 2019-06-05
 - Upgrade lerna to 3.x

--- a/packages/top-app-bar/src/mwc-top-app-bar-base.ts
+++ b/packages/top-app-bar/src/mwc-top-app-bar-base.ts
@@ -35,6 +35,7 @@ export class TopAppBarBase extends TopAppBarBaseBase {
     return {
       'mdc-top-app-bar--dense': this.dense,
       'mdc-top-app-bar--prominent': this.prominent,
+      'center-title': this.centerTitle,
     };
   }
 

--- a/packages/top-app-bar/src/mwc-top-app-bar.scss
+++ b/packages/top-app-bar/src/mwc-top-app-bar.scss
@@ -65,6 +65,15 @@ limitations under the License.
   }
 }
 
+.center-title {
+  // set flex-basis of other sections to 0 to force title to be always centered
+  // NOTE: this may cause overlapping on very small sizes
+  .mdc-top-app-bar__section--align-start,
+  .mdc-top-app-bar__section--align-end {
+    flex-basis: 0;
+  }
+}
+
 // dense & prominent theming needs a more specific override
 .mdc-top-app-bar--dense.mdc-top-app-bar--prominent .mdc-top-app-bar__section--align-center .mdc-top-app-bar__title {
   @include centerPadding();


### PR DESCRIPTION
This should be the original behavior before removal