### PR TITLE
Add support for ESM "module" entrypoint

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-button.js",
+  "module": "mwc-button.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-checkbox.js",
+  "module": "mwc-checkbox.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-drawer.js",
+  "module": "mwc-drawer.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/fab/package.json
+++ b/packages/fab/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-fab.js",
+  "module": "mwc-fab.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/floating-label/package.json
+++ b/packages/floating-label/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-floating-label-directive.js",
+  "module": "mwc-floating-label-directive.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/formfield/package.json
+++ b/packages/formfield/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-formfield.js",
+  "module": "mwc-formfield.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/icon-button-toggle/package.json
+++ b/packages/icon-button-toggle/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-icon-button-toggle.js",
+  "module": "mwc-icon-button-toggle.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-icon-button.js",
+  "module": "mwc-icon-button.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-icon.js",
+  "module": "mwc-icon.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/line-ripple/package.json
+++ b/packages/line-ripple/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-line-ripple-directive.js",
+  "module": "mwc-line-ripple-directive.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/linear-progress/package.json
+++ b/packages/linear-progress/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-linear-progress.js",
+  "module": "mwc-linear-progress.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/notched-outline/package.json
+++ b/packages/notched-outline/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-notched-outline.js",
+  "module": "mwc-notched-outline.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-radio.js",
+  "module": "mwc-radio.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-ripple.js",
+  "module": "mwc-ripple.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-slider.js",
+  "module": "mwc-slider.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-snackbar.js",
+  "module": "mwc-snackbar.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-switch.js",
+  "module": "mwc-switch.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/tab-bar/package.json
+++ b/packages/tab-bar/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-tab-bar.js",
+  "module": "mwc-tab-bar.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/tab-indicator/package.json
+++ b/packages/tab-indicator/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-tab-indicator.js",
+  "module": "mwc-tab-indicator.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/tab-scroller/package.json
+++ b/packages/tab-scroller/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-tab-scroller.js",
+  "module": "mwc-tab-scroller.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-tab.js",
+  "module": "mwc-tab.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-textarea.js",
+  "module": "mwc-textarea.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-textfield.js",
+  "module": "mwc-textfield.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/packages/top-app-bar-fixed/package.json
+++ b/packages/top-app-bar-fixed/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-top-app-bar-fixed.js",
+  "module": "mwc-top-app-bar-fixed.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",

--- a/packages/top-app-bar/package.json
+++ b/packages/top-app-bar/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.0",
   "description": "",
   "main": "mwc-top-app-bar.js",
+  "module": "mwc-top-app-bar.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/material-components/material-components-web-components.git",


### PR DESCRIPTION
This lets tools like pika.dev detect that your package is written as an ES Module and not Common.js.  See https://github.com/rollup/rollup/wiki/pkg.module for more info