### PR TITLE
Import TypeScript helpers from tslib, instead of inlining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Published JavaScript files no longer include inlined TypeScript helpers such
+  as `__decorate`. Instead, helpers are now imported from the
+  [`tslib`](https://github.com/microsoft/tslib) module dependency. This reduces
+  code size by allowing multiple components to share the same helpers, and
+  eliminates *"this has been rewritten to undefined"* errors from Rollup.
+  ([#439](https://github.com/material-components/material-components-web-components/pull/439))
+
 ## [0.7.1] - 2019-08-27
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -6878,8 +6878,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6903,15 +6902,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6928,22 +6925,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7074,8 +7068,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7089,7 +7082,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7106,7 +7098,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7115,15 +7106,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7144,7 +7133,6 @@
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7233,8 +7221,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7248,7 +7235,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7344,8 +7330,7 @@
           "version": "5.1.2",
           "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7387,7 +7372,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7409,7 +7393,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7458,15 +7441,13 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -12,7 +12,8 @@
     "@material/base": "^3.0.0",
     "@material/dom": "^3.1.0",
     "lit-element": "^2.2.1",
-    "lit-html": "^1.0.0"
+    "lit-html": "^1.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -18,7 +18,8 @@
     "@material/button": "^3.0.0",
     "@material/mwc-base": "^0.7.0",
     "@material/mwc-icon": "^0.7.1",
-    "@material/mwc-ripple": "^0.7.1"
+    "@material/mwc-ripple": "^0.7.1",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@material/checkbox": "^3.0.0",
     "@material/mwc-base": "^0.7.0",
-    "@material/mwc-ripple": "^0.7.1"
+    "@material/mwc-ripple": "^0.7.1",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -19,6 +19,7 @@
     "@material/drawer": "^3.0.0",
     "@material/mwc-base": "^0.7.0",
     "blocking-elements": "^0.1.0",
+    "tslib": "^1.10.0",
     "wicg-inert": "^2.1.3"
   },
   "publishConfig": {

--- a/packages/fab/package.json
+++ b/packages/fab/package.json
@@ -18,7 +18,8 @@
     "@material/fab": "^3.0.0",
     "@material/mwc-base": "^0.7.0",
     "@material/mwc-icon": "^0.7.1",
-    "@material/mwc-ripple": "^0.7.1"
+    "@material/mwc-ripple": "^0.7.1",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/floating-label/package.json
+++ b/packages/floating-label/package.json
@@ -13,7 +13,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/floating-label": "^3.0.0",
-    "lit-html": "^1.0.0"
+    "lit-html": "^1.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/formfield/package.json
+++ b/packages/formfield/package.json
@@ -16,7 +16,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/form-field": "^3.0.0",
-    "@material/mwc-base": "^0.7.0"
+    "@material/mwc-base": "^0.7.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/icon-button-toggle/package.json
+++ b/packages/icon-button-toggle/package.json
@@ -19,7 +19,8 @@
     "@material/mwc-base": "^0.7.0",
     "@material/mwc-icon": "^0.7.1",
     "@material/mwc-icon-button": "^0.7.1",
-    "@material/mwc-ripple": "^0.7.1"
+    "@material/mwc-ripple": "^0.7.1",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -18,7 +18,8 @@
     "@material/icon-button": "^3.0.0",
     "@material/mwc-base": "^0.7.0",
     "@material/mwc-icon": "^0.7.1",
-    "@material/mwc-ripple": "^0.7.1"
+    "@material/mwc-ripple": "^0.7.1",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -15,7 +15,8 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "@material/mwc-base": "^0.7.0"
+    "@material/mwc-base": "^0.7.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/line-ripple/package.json
+++ b/packages/line-ripple/package.json
@@ -13,7 +13,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/line-ripple": "^3.0.0",
-    "lit-html": "^1.0.0"
+    "lit-html": "^1.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/linear-progress/package.json
+++ b/packages/linear-progress/package.json
@@ -16,7 +16,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/linear-progress": "^3.0.0",
-    "@material/mwc-base": "^0.7.0"
+    "@material/mwc-base": "^0.7.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/notched-outline/package.json
+++ b/packages/notched-outline/package.json
@@ -18,7 +18,8 @@
     "@material/mwc-base": "^0.7.0",
     "@material/notched-outline": "^3.0.0",
     "@material/shape": "^3.0.0",
-    "@material/theme": "^3.0.0"
+    "@material/theme": "^3.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@material/mwc-base": "^0.7.0",
     "@material/mwc-ripple": "^0.7.1",
-    "@material/radio": "^3.0.0"
+    "@material/radio": "^3.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -18,7 +18,8 @@
     "@material/dom": "^3.1.0",
     "@material/mwc-base": "^0.7.0",
     "@material/ripple": "^3.0.0",
-    "lit-html": "^1.0.0"
+    "lit-html": "^1.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@material/mwc-base": "^0.7.0",
     "@material/slider": "^3.0.0",
-    "lit-html": "^1.0.0"
+    "lit-html": "^1.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -16,7 +16,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/mwc-base": "^0.7.0",
-    "@material/snackbar": "^3.0.0"
+    "@material/snackbar": "^3.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "@material/mwc-base": "^0.7.0",
     "@material/mwc-ripple": "^0.7.1",
-    "@material/switch": "^3.0.0"
+    "@material/switch": "^3.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tab-bar/package.json
+++ b/packages/tab-bar/package.json
@@ -19,7 +19,8 @@
     "@material/mwc-base": "^0.7.0",
     "@material/mwc-tab": "^0.7.1",
     "@material/mwc-tab-scroller": "^0.7.1",
-    "@material/tab-bar": "^3.0.0"
+    "@material/tab-bar": "^3.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tab-indicator/package.json
+++ b/packages/tab-indicator/package.json
@@ -17,7 +17,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/mwc-base": "^0.7.0",
-    "@material/tab-indicator": "^3.0.0"
+    "@material/tab-indicator": "^3.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tab-scroller/package.json
+++ b/packages/tab-scroller/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "@material/dom": "^3.1.0",
     "@material/mwc-base": "^0.7.0",
-    "@material/tab-scroller": "^3.0.0"
+    "@material/tab-scroller": "^3.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -20,7 +20,8 @@
     "@material/mwc-icon": "^0.7.1",
     "@material/mwc-ripple": "^0.7.1",
     "@material/mwc-tab-indicator": "^0.7.1",
-    "@material/tab": "^3.0.0"
+    "@material/tab": "^3.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@material/mwc-base": "^0.7.0",
     "@material/mwc-textfield": "^0.7.1",
-    "@material/textfield": "^3.0.0"
+    "@material/textfield": "^3.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -19,7 +19,8 @@
     "@material/shape": "^3.0.0",
     "@material/textfield": "^3.0.0",
     "@material/theme": "^3.0.0",
-    "lit-html": "^1.0.0"
+    "lit-html": "^1.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/top-app-bar-fixed/package.json
+++ b/packages/top-app-bar-fixed/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "@material/mwc-base": "^0.7.0",
     "@material/mwc-top-app-bar": "^0.7.1",
-    "@material/top-app-bar": "^3.0.0"
+    "@material/top-app-bar": "^3.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/top-app-bar/package.json
+++ b/packages/top-app-bar/package.json
@@ -17,7 +17,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/mwc-base": "^0.7.0",
-    "@material/top-app-bar": "^3.0.0"
+    "@material/top-app-bar": "^3.0.0",
+    "tslib": "^1.10.0"
   },
   "publishConfig": {
     "access": "public"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "paths": {
       "@material/mwc-*": ["./*/src"]
     },
-    "composite": true
+    "composite": true,
+    "importHelpers": true
   },
   "include": [
     "custom_typings/**/*.ts",


### PR DESCRIPTION
Published JavaScript files no longer include inlined TypeScript helpers such as `__decorate`. Instead, helpers are now imported from the [`tslib`](https://github.com/microsoft/tslib) module dependency. This reduces code size by allowing multiple components to share the same helpers, and eliminates *"this has been rewritten to undefined"* errors from Rollup.

Fixes https://github.com/material-components/material-components-web-components/issues/257