### PR TITLE
Import symbols from lit-element and lit-html directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - **BREAKING:** mwc-textfield's custom `.blur()` function will now call
   `.blur()` on the native internal input instead of just forcing focus styles to
   disapprear.
+- **BREAKING** `mwc-base/base-element` no longer exports any of the
+  `lit-element` or `lit-html` APIs (e.g. `LitElement`, `customElement`,
+  `classMap`). Users should import directly from the `lit-element` and
+  `lit-html` modules instead.
 
 ### Fixed
 

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -13,7 +13,6 @@
     "@material/dom": "^3.1.0",
     "@material/ripple": "^3.0.0",
     "lit-element": "^2.2.1",
-    "lit-html": "^1.0.0",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/base/src/base-element.ts
+++ b/packages/base/src/base-element.ts
@@ -19,9 +19,6 @@ import {MDCFoundation} from '@material/base';
 import {LitElement} from 'lit-element';
 
 import {Constructor} from './utils.js';
-
-export * from 'lit-element';
-export {classMap} from 'lit-html/directives/class-map.js';
 export {observer} from './observer.js';
 export {addHasRemoveClass} from './utils.js';
 export * from '@material/base/types.js';

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -19,6 +19,8 @@
     "@material/mwc-base": "^0.8.0",
     "@material/mwc-icon": "^0.8.0",
     "@material/mwc-ripple": "^0.8.0",
+    "lit-element": "^2.2.1",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/button/src/mwc-button-base.ts
+++ b/packages/button/src/mwc-button-base.ts
@@ -14,9 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {classMap, html, LitElement, property, query} from '@material/mwc-base/base-element';
 import {HTMLElementWithRipple} from '@material/mwc-base/form-element';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
+import {html, LitElement, property, query} from 'lit-element';
+import {classMap} from 'lit-html/directives/class-map';
 
 export class ButtonBase extends LitElement {
   @property({type: Boolean}) raised = false;

--- a/packages/button/src/mwc-button.ts
+++ b/packages/button/src/mwc-button.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/base-element';
+import {customElement} from 'lit-element';
 
 import {ButtonBase} from './mwc-button-base.js';
 import {style} from './mwc-button-css.js';

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -18,6 +18,7 @@
     "@material/checkbox": "^3.0.0",
     "@material/mwc-base": "^0.8.0",
     "@material/mwc-ripple": "^0.8.0",
+    "lit-element": "^2.2.1",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/checkbox/src/mwc-checkbox-base.ts
+++ b/packages/checkbox/src/mwc-checkbox-base.ts
@@ -16,8 +16,9 @@ limitations under the License.
 */
 import {MDCCheckboxAdapter} from '@material/checkbox/adapter.js';
 import MDCCheckboxFoundation from '@material/checkbox/foundation.js';
-import {addHasRemoveClass, FormElement, html, HTMLElementWithRipple, observer, property, query, RippleSurface} from '@material/mwc-base/form-element.js';
+import {addHasRemoveClass, FormElement, HTMLElementWithRipple, observer, RippleSurface} from '@material/mwc-base/form-element.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
+import {html, property, query} from 'lit-element';
 
 export class CheckboxBase extends FormElement {
   @query('.mdc-checkbox') protected mdcRoot!: HTMLElementWithRipple;

--- a/packages/checkbox/src/mwc-checkbox.ts
+++ b/packages/checkbox/src/mwc-checkbox.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/form-element.js';
+import {customElement} from 'lit-element';
 
 import {CheckboxBase} from './mwc-checkbox-base.js';
 import {style} from './mwc-checkbox-css.js';

--- a/packages/drawer/package.json
+++ b/packages/drawer/package.json
@@ -19,6 +19,8 @@
     "@material/drawer": "^3.0.0",
     "@material/mwc-base": "^0.8.0",
     "blocking-elements": "^0.1.0",
+    "lit-element": "^2.2.1",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0",
     "wicg-inert": "^2.2.0"
   },

--- a/packages/drawer/src/mwc-drawer-base.ts
+++ b/packages/drawer/src/mwc-drawer-base.ts
@@ -26,8 +26,10 @@ import {MDCDrawerAdapter} from '@material/drawer/adapter.js';
 import {strings} from '@material/drawer/constants.js';
 import MDCDismissibleDrawerFoundation from '@material/drawer/dismissible/foundation.js';
 import MDCModalDrawerFoundation from '@material/drawer/modal/foundation.js';
-import {addHasRemoveClass, BaseElement, classMap, html, observer, property, PropertyValues, query} from '@material/mwc-base/base-element.js';
+import {addHasRemoveClass, BaseElement, observer} from '@material/mwc-base/base-element.js';
 import {DocumentWithBlockingElements} from 'blocking-elements';
+import {html, property, PropertyValues, query} from 'lit-element';
+import {classMap} from 'lit-html/directives/class-map';
 
 interface InertableHTMLElement extends HTMLElement {
   inert?: boolean;

--- a/packages/drawer/src/mwc-drawer.ts
+++ b/packages/drawer/src/mwc-drawer.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/base-element.js';
+import {customElement} from 'lit-element';
 
 import {DrawerBase} from './mwc-drawer-base.js';
 import {style} from './mwc-drawer-css.js';

--- a/packages/fab/package.json
+++ b/packages/fab/package.json
@@ -19,6 +19,8 @@
     "@material/mwc-base": "^0.8.0",
     "@material/mwc-icon": "^0.8.0",
     "@material/mwc-ripple": "^0.8.0",
+    "lit-element": "^2.2.1",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/fab/src/mwc-fab-base.ts
+++ b/packages/fab/src/mwc-fab-base.ts
@@ -14,8 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {classMap, html, LitElement, property} from '@material/mwc-base/base-element';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
+import {html, LitElement, property} from 'lit-element';
+import {classMap} from 'lit-html/directives/class-map';
 
 export class FabBase extends LitElement {
   @property({type: Boolean}) mini = false;

--- a/packages/fab/src/mwc-fab.ts
+++ b/packages/fab/src/mwc-fab.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/base-element';
+import {customElement} from 'lit-element';
 
 import {FabBase} from './mwc-fab-base.js';
 import {style} from './mwc-fab-css.js';

--- a/packages/floating-label/package.json
+++ b/packages/floating-label/package.json
@@ -13,7 +13,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/floating-label": "^3.0.0",
-    "lit-html": "^1.0.0",
+    "lit-element": "^2.2.1",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/formfield/package.json
+++ b/packages/formfield/package.json
@@ -17,6 +17,8 @@
   "dependencies": {
     "@material/form-field": "^3.0.0",
     "@material/mwc-base": "^0.8.0",
+    "lit-element": "^2.2.1",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/formfield/src/mwc-formfield-base.ts
+++ b/packages/formfield/src/mwc-formfield-base.ts
@@ -16,9 +16,11 @@ limitations under the License.
 */
 import {MDCFormFieldAdapter} from '@material/form-field/adapter.js';
 import MDCFormFieldFoundation from '@material/form-field/foundation.js';
-import {BaseElement, classMap, EventType, html, observer, property, query, SpecificEventListener} from '@material/mwc-base/base-element.js';
+import {BaseElement, EventType, observer, SpecificEventListener} from '@material/mwc-base/base-element.js';
 import {FormElement} from '@material/mwc-base/form-element.js';
 import {findAssignedElement} from '@material/mwc-base/utils.js';
+import {html, property, query} from 'lit-element';
+import {classMap} from 'lit-html/directives/class-map';
 
 export class FormfieldBase extends BaseElement {
   @property({type: Boolean}) alignEnd = false;

--- a/packages/formfield/src/mwc-formfield.ts
+++ b/packages/formfield/src/mwc-formfield.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/base-element.js';
+import {customElement} from 'lit-element';
 
 import {FormfieldBase} from './mwc-formfield-base.js';
 import {style} from './mwc-formfield-css.js';

--- a/packages/icon-button-toggle/package.json
+++ b/packages/icon-button-toggle/package.json
@@ -20,6 +20,7 @@
     "@material/mwc-icon": "^0.8.0",
     "@material/mwc-icon-button": "^0.8.0",
     "@material/mwc-ripple": "^0.8.0",
+    "lit-element": "^2.2.1",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/icon-button-toggle/src/mwc-icon-button-toggle-base.ts
+++ b/packages/icon-button-toggle/src/mwc-icon-button-toggle-base.ts
@@ -17,8 +17,9 @@ limitations under the License.
 
 import {MDCIconButtonToggleAdapter} from '@material/icon-button/adapter.js';
 import MDCIconButtonToggleFoundation from '@material/icon-button/foundation.js';
-import {addHasRemoveClass, BaseElement, html, observer, property, query} from '@material/mwc-base/base-element.js';
+import {addHasRemoveClass, BaseElement, observer} from '@material/mwc-base/base-element.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
+import {html, property, query} from 'lit-element';
 
 export class IconButtonToggleBase extends BaseElement {
   protected mdcFoundationClass = MDCIconButtonToggleFoundation;

--- a/packages/icon-button-toggle/src/mwc-icon-button-toggle.ts
+++ b/packages/icon-button-toggle/src/mwc-icon-button-toggle.ts
@@ -15,8 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {customElement} from '@material/mwc-base/base-element';
 import {style} from '@material/mwc-icon-button/mwc-icon-button-css';
+import {customElement} from 'lit-element';
 
 import {IconButtonToggleBase} from './mwc-icon-button-toggle-base';
 

--- a/packages/icon-button/package.json
+++ b/packages/icon-button/package.json
@@ -19,6 +19,7 @@
     "@material/mwc-base": "^0.8.0",
     "@material/mwc-icon": "^0.8.0",
     "@material/mwc-ripple": "^0.8.0",
+    "lit-element": "^2.2.1",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/icon-button/src/mwc-icon-button-base.ts
+++ b/packages/icon-button/src/mwc-icon-button-base.ts
@@ -14,8 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {html, LitElement, property} from '@material/mwc-base/base-element';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
+import {html, LitElement, property} from 'lit-element';
 
 export class IconButtonBase extends LitElement {
   @property({type: Boolean, reflect: true}) disabled = false;

--- a/packages/icon-button/src/mwc-icon-button.ts
+++ b/packages/icon-button/src/mwc-icon-button.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {customElement} from '@material/mwc-base/base-element.js';
+import {customElement} from 'lit-element';
 
 import {IconButtonBase} from './mwc-icon-button-base.js';
 import {style} from './mwc-icon-button-css.js';

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -16,6 +16,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/mwc-base": "^0.8.0",
+    "lit-element": "^2.2.1",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/icon/src/mwc-icon.ts
+++ b/packages/icon/src/mwc-icon.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement, html, LitElement} from '@material/mwc-base/base-element';
+import {customElement, html, LitElement} from 'lit-element';
 
 import {style} from './mwc-icon-host-css.js';
 

--- a/packages/line-ripple/package.json
+++ b/packages/line-ripple/package.json
@@ -13,7 +13,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/line-ripple": "^3.0.0",
-    "lit-html": "^1.0.0",
+    "lit-element": "^2.2.1",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/linear-progress/package.json
+++ b/packages/linear-progress/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@material/linear-progress": "^3.0.0",
     "@material/mwc-base": "^0.8.0",
+    "lit-element": "^2.2.1",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/linear-progress/src/mwc-linear-progress-base.ts
+++ b/packages/linear-progress/src/mwc-linear-progress-base.ts
@@ -16,7 +16,8 @@ limitations under the License.
 */
 import {MDCLinearProgressAdapter} from '@material/linear-progress/adapter.js';
 import MDCLinearProgressFoundation from '@material/linear-progress/foundation.js';
-import {addHasRemoveClass, BaseElement, html, observer, property, query} from '@material/mwc-base/base-element.js';
+import {addHasRemoveClass, BaseElement, observer} from '@material/mwc-base/base-element.js';
+import {html, property, query} from 'lit-element';
 
 export class LinearProgressBase extends BaseElement {
   protected mdcFoundation!: MDCLinearProgressFoundation;

--- a/packages/linear-progress/src/mwc-linear-progress.ts
+++ b/packages/linear-progress/src/mwc-linear-progress.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/base-element.js';
+import {customElement} from 'lit-element';
 
 import {LinearProgressBase} from './mwc-linear-progress-base.js';
 import {style} from './mwc-linear-progress-css.js';

--- a/packages/notched-outline/package.json
+++ b/packages/notched-outline/package.json
@@ -19,6 +19,7 @@
     "@material/notched-outline": "^3.0.0",
     "@material/shape": "^3.0.0",
     "@material/theme": "^3.0.0",
+    "lit-element": "^2.2.1",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/notched-outline/src/mwc-notched-outline-base.ts
+++ b/packages/notched-outline/src/mwc-notched-outline-base.ts
@@ -14,10 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {BaseElement, html, property, query} from '@material/mwc-base/form-element.js';
+import {BaseElement} from '@material/mwc-base/form-element.js';
 import {MDCNotchedOutlineAdapter} from '@material/notched-outline/adapter.js';
 import {MDCNotchedOutlineFoundation} from '@material/notched-outline/foundation.js';
-
+import {html, property, query} from 'lit-element';
 
 export class NotchedOutlineBase extends BaseElement {
   @query('.mdc-notched-outline') protected mdcRoot!: HTMLElement;

--- a/packages/notched-outline/src/mwc-notched-outline.ts
+++ b/packages/notched-outline/src/mwc-notched-outline.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/form-element.js';
+import {customElement} from 'lit-element';
 
 import {NotchedOutlineBase} from './mwc-notched-outline-base.js';
 import {style} from './mwc-notched-outline-css.js';

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -18,6 +18,7 @@
     "@material/mwc-base": "^0.8.0",
     "@material/mwc-ripple": "^0.8.0",
     "@material/radio": "^3.0.0",
+    "lit-element": "^2.2.1",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/radio/src/mwc-radio-base.ts
+++ b/packages/radio/src/mwc-radio-base.ts
@@ -14,10 +14,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {addHasRemoveClass, FormElement, html, HTMLElementWithRipple, observer, property, query} from '@material/mwc-base/form-element.js';
+import {addHasRemoveClass, FormElement, HTMLElementWithRipple, observer} from '@material/mwc-base/form-element.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 import {MDCRadioAdapter} from '@material/radio/adapter.js';
 import MDCRadioFoundation from '@material/radio/foundation.js';
+import {html, property, query} from 'lit-element';
 
 export class RadioBase extends FormElement {
   @query('.mdc-radio') protected mdcRoot!: HTMLElementWithRipple;

--- a/packages/radio/src/mwc-radio.ts
+++ b/packages/radio/src/mwc-radio.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/form-element.js';
+import {customElement} from 'lit-element';
 
 import {RadioBase} from './mwc-radio-base.js';
 import {style} from './mwc-radio-css.js';

--- a/packages/ripple/package.json
+++ b/packages/ripple/package.json
@@ -18,7 +18,8 @@
     "@material/dom": "^3.1.0",
     "@material/mwc-base": "^0.8.0",
     "@material/ripple": "^3.0.0",
-    "lit-html": "^1.0.0",
+    "lit-element": "^2.2.1",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/ripple/src/mwc-ripple-base.ts
+++ b/packages/ripple/src/mwc-ripple-base.ts
@@ -14,7 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {classMap, html, LitElement, property} from '@material/mwc-base/base-element';
+import {html, LitElement, property} from 'lit-element';
+import {classMap} from 'lit-html/directives/class-map';
 
 import {ripple, RippleOptions} from './ripple-directive.js';
 

--- a/packages/ripple/src/mwc-ripple.ts
+++ b/packages/ripple/src/mwc-ripple.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/base-element';
+import {customElement} from 'lit-element';
 
 import {RippleBase} from './mwc-ripple-base.js';
 import {style} from './mwc-ripple-css.js';

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@material/mwc-base": "^0.8.0",
     "@material/slider": "^3.0.0",
-    "lit-html": "^1.0.0",
+    "lit-element": "^2.2.1",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/slider/src/mwc-slider-base.ts
+++ b/packages/slider/src/mwc-slider-base.ts
@@ -14,9 +14,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {addHasRemoveClass, classMap, EventType, FormElement, html, observer, property, query, SpecificEventListener, TemplateResult} from '@material/mwc-base/form-element.js';
+import {addHasRemoveClass, EventType, FormElement, observer, SpecificEventListener} from '@material/mwc-base/form-element.js';
 import {MDCSliderAdapter} from '@material/slider/adapter.js';
 import MDCSliderFoundation from '@material/slider/foundation.js';
+import {html, property, query, TemplateResult} from 'lit-element';
+import {classMap} from 'lit-html/directives/class-map';
 import {repeat} from 'lit-html/directives/repeat.js';
 
 const {INPUT_EVENT, CHANGE_EVENT} = MDCSliderFoundation.strings;

--- a/packages/slider/src/mwc-slider.ts
+++ b/packages/slider/src/mwc-slider.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/form-element.js';
+import {customElement} from 'lit-element';
 
 import {SliderBase} from './mwc-slider-base.js';
 import {style} from './mwc-slider-css.js';

--- a/packages/snackbar/package.json
+++ b/packages/snackbar/package.json
@@ -17,6 +17,8 @@
   "dependencies": {
     "@material/mwc-base": "^0.8.0",
     "@material/snackbar": "^3.0.0",
+    "lit-element": "^2.2.1",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/snackbar/src/mwc-snackbar-base.ts
+++ b/packages/snackbar/src/mwc-snackbar-base.ts
@@ -14,10 +14,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {addHasRemoveClass, BaseElement, classMap, html, observer, property, query} from '@material/mwc-base/base-element.js';
+import {addHasRemoveClass, BaseElement, observer} from '@material/mwc-base/base-element.js';
 import {MDCSnackbarAdapter} from '@material/snackbar/adapter.js';
 import MDCSnackbarFoundation from '@material/snackbar/foundation.js';
 import {MDCSnackbarCloseEventDetail} from '@material/snackbar/types';
+import {html, property, query} from 'lit-element';
+import {classMap} from 'lit-html/directives/class-map';
 
 import {accessibleSnackbarLabel} from './accessible-snackbar-label-directive';
 

--- a/packages/snackbar/src/mwc-snackbar.ts
+++ b/packages/snackbar/src/mwc-snackbar.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/base-element.js';
+import {customElement} from 'lit-element';
 
 import {SnackbarBase} from './mwc-snackbar-base.js';
 import {style} from './mwc-snackbar-css.js';

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -15,6 +15,7 @@
     "@material/mwc-base": "^0.8.0",
     "@material/mwc-ripple": "^0.8.0",
     "@material/switch": "^3.0.0",
+    "lit-element": "^2.2.1",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/switch/src/mwc-switch-base.ts
+++ b/packages/switch/src/mwc-switch-base.ts
@@ -14,10 +14,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {addHasRemoveClass, FormElement, html, HTMLElementWithRipple, observer, property, query} from '@material/mwc-base/form-element.js';
+import {addHasRemoveClass, FormElement, HTMLElementWithRipple, observer} from '@material/mwc-base/form-element.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive.js';
 import {MDCSwitchAdapter} from '@material/switch/adapter';
 import MDCSwitchFoundation from '@material/switch/foundation.js';
+import {html, property, query} from 'lit-element';
 
 export class SwitchBase extends FormElement {
   @property({type: Boolean})

--- a/packages/switch/src/mwc-switch.ts
+++ b/packages/switch/src/mwc-switch.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/form-element.js';
+import {customElement} from 'lit-element';
 
 import {SwitchBase} from './mwc-switch-base.js';
 import {style} from './mwc-switch-css.js';

--- a/packages/tab-bar/package.json
+++ b/packages/tab-bar/package.json
@@ -20,6 +20,7 @@
     "@material/mwc-tab": "^0.8.0",
     "@material/mwc-tab-scroller": "^0.8.0",
     "@material/tab-bar": "^3.0.0",
+    "lit-element": "^2.2.1",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/tab-bar/src/mwc-tab-bar-base.ts
+++ b/packages/tab-bar/src/mwc-tab-bar-base.ts
@@ -18,12 +18,13 @@ limitations under the License.
 import '@material/mwc-tab';
 import '@material/mwc-tab-scroller';
 
-import {BaseElement, html, observer, property, query} from '@material/mwc-base/base-element.js';
+import {BaseElement, observer} from '@material/mwc-base/base-element.js';
 import {Tab} from '@material/mwc-tab';
 import {TabScroller} from '@material/mwc-tab-scroller';
 import {MDCTabBarAdapter} from '@material/tab-bar/adapter';
 import MDCTabBarFoundation from '@material/tab-bar/foundation';
 import {MDCTabInteractionEvent} from '@material/tab/types';
+import {html, property, query} from 'lit-element';
 
 export class TabBarBase extends BaseElement {
   protected mdcFoundation!: MDCTabBarFoundation;

--- a/packages/tab-bar/src/mwc-tab-bar.ts
+++ b/packages/tab-bar/src/mwc-tab-bar.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/base-element.js';
+import {customElement} from 'lit-element';
 
 import {TabBarBase} from './mwc-tab-bar-base.js';
 import {style} from './mwc-tab-bar-css';

--- a/packages/tab-indicator/package.json
+++ b/packages/tab-indicator/package.json
@@ -18,6 +18,8 @@
   "dependencies": {
     "@material/mwc-base": "^0.8.0",
     "@material/tab-indicator": "^3.0.0",
+    "lit-element": "^2.2.1",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/tab-indicator/src/mwc-tab-indicator-base.ts
+++ b/packages/tab-indicator/src/mwc-tab-indicator-base.ts
@@ -14,11 +14,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {addHasRemoveClass, BaseElement, classMap, html, property, PropertyValues, query} from '@material/mwc-base/base-element.js';
+import {addHasRemoveClass, BaseElement} from '@material/mwc-base/base-element.js';
 import {MDCTabIndicatorAdapter} from '@material/tab-indicator/adapter';
 import MDCFadingTabIndicatorFoundation from '@material/tab-indicator/fading-foundation.js';
 import MDCTabIndicatorFoundation from '@material/tab-indicator/foundation';
 import MDCSlidingTabIndicatorFoundation from '@material/tab-indicator/sliding-foundation.js';
+import {html, property, PropertyValues, query} from 'lit-element';
+import {classMap} from 'lit-html/directives/class-map';
 
 export class TabIndicatorBase extends BaseElement {
   protected mdcFoundation!: MDCTabIndicatorFoundation;

--- a/packages/tab-indicator/src/mwc-tab-indicator.ts
+++ b/packages/tab-indicator/src/mwc-tab-indicator.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/base-element.js';
+import {customElement} from 'lit-element';
 
 import {TabIndicatorBase} from './mwc-tab-indicator-base.js';
 import {style} from './mwc-tab-indicator-css.js';

--- a/packages/tab-scroller/package.json
+++ b/packages/tab-scroller/package.json
@@ -19,6 +19,7 @@
     "@material/dom": "^3.1.0",
     "@material/mwc-base": "^0.8.0",
     "@material/tab-scroller": "^3.0.0",
+    "lit-element": "^2.2.1",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/tab-scroller/src/mwc-tab-scroller-base.ts
+++ b/packages/tab-scroller/src/mwc-tab-scroller-base.ts
@@ -15,9 +15,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import {matches} from '@material/dom/ponyfill';
-import {addHasRemoveClass, BaseElement, eventOptions, html, query} from '@material/mwc-base/base-element';
+import {addHasRemoveClass, BaseElement} from '@material/mwc-base/base-element';
 import {MDCTabScrollerAdapter} from '@material/tab-scroller/adapter';
 import MDCTabScrollerFoundation from '@material/tab-scroller/foundation.js';
+import {eventOptions, html, query} from 'lit-element';
 
 export class TabScrollerBase extends BaseElement {
   protected mdcFoundation!: MDCTabScrollerFoundation;

--- a/packages/tab-scroller/src/mwc-tab-scroller.ts
+++ b/packages/tab-scroller/src/mwc-tab-scroller.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/base-element';
+import {customElement} from 'lit-element';
 
 import {TabScrollerBase} from './mwc-tab-scroller-base.js';
 import {style} from './mwc-tab-scroller-css.js';

--- a/packages/tab/package.json
+++ b/packages/tab/package.json
@@ -21,6 +21,8 @@
     "@material/mwc-ripple": "^0.8.0",
     "@material/mwc-tab-indicator": "^0.8.0",
     "@material/tab": "^3.0.0",
+    "lit-element": "^2.2.1",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/tab/src/mwc-tab-base.ts
+++ b/packages/tab/src/mwc-tab-base.ts
@@ -17,11 +17,13 @@ limitations under the License.
 // Make TypeScript not remove the import.
 import '@material/mwc-tab-indicator';
 
-import {addHasRemoveClass, BaseElement, classMap, html, property, query} from '@material/mwc-base/base-element.js';
+import {addHasRemoveClass, BaseElement} from '@material/mwc-base/base-element.js';
 import {ripple} from '@material/mwc-ripple/ripple-directive';
 import {TabIndicator} from '@material/mwc-tab-indicator';
 import {MDCTabAdapter} from '@material/tab/adapter';
 import MDCTabFoundation from '@material/tab/foundation';
+import {html, property, query} from 'lit-element';
+import {classMap} from 'lit-html/directives/class-map';
 
 import {style} from './mwc-tab-css';
 

--- a/packages/tab/src/mwc-tab.ts
+++ b/packages/tab/src/mwc-tab.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/base-element.js';
+import {customElement} from 'lit-element';
 
 import {TabBase} from './mwc-tab-base.js';
 import {style} from './mwc-tab-css';

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -13,6 +13,8 @@
     "@material/mwc-base": "^0.8.0",
     "@material/mwc-textfield": "^0.8.0",
     "@material/textfield": "^3.0.0",
+    "lit-element": "^2.2.1",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/textarea/src/mwc-textarea-base.ts
+++ b/packages/textarea/src/mwc-textarea-base.ts
@@ -15,9 +15,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {classMap, html, property, query} from '@material/mwc-base/form-element.js';
 import {characterCounter} from '@material/mwc-textfield/character-counter/mwc-character-counter-directive.js';
 import {TextFieldBase} from '@material/mwc-textfield/mwc-textfield-base.js';
+import {html, property, query} from 'lit-element';
+import {classMap} from 'lit-html/directives/class-map';
 
 export {TextFieldType} from '@material/mwc-textfield/mwc-textfield-base.js';
 

--- a/packages/textarea/src/mwc-textarea.ts
+++ b/packages/textarea/src/mwc-textarea.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {customElement} from '@material/mwc-base/form-element.js';
+import {customElement} from 'lit-element';
 import {TextAreaBase} from './mwc-textarea-base.js';
 import {style} from './mwc-textarea-css.js';
 

--- a/packages/textfield/package.json
+++ b/packages/textfield/package.json
@@ -11,6 +11,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@material/floating-label": "^3.0.0",
+    "@material/line-ripple": "^3.0.0",
     "@material/mwc-base": "^0.8.0",
     "@material/mwc-floating-label": "^0.8.0",
     "@material/mwc-icon": "^0.8.0",
@@ -19,8 +20,8 @@
     "@material/shape": "^3.0.0",
     "@material/textfield": "^3.0.0",
     "@material/theme": "^3.0.0",
-    "@material/line-ripple": "^3.0.0",
-    "lit-html": "^1.0.0",
+    "lit-element": "^2.2.1",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/textfield/src/mwc-textfield-base.ts
+++ b/packages/textfield/src/mwc-textfield-base.ts
@@ -18,13 +18,15 @@ import '@material/mwc-notched-outline';
 
 import {MDCFloatingLabelFoundation} from '@material/floating-label/foundation.js';
 import {MDCLineRippleFoundation} from '@material/line-ripple/foundation.js';
-import {addHasRemoveClass, classMap, FormElement, html, property, PropertyValues, query, TemplateResult} from '@material/mwc-base/form-element.js';
+import {addHasRemoveClass, FormElement} from '@material/mwc-base/form-element.js';
 import {floatingLabel, FloatingLabel} from '@material/mwc-floating-label';
 import {lineRipple, LineRipple} from '@material/mwc-line-ripple';
 import {NotchedOutline} from '@material/mwc-notched-outline';
 import {MDCTextFieldAdapter, MDCTextFieldInputAdapter, MDCTextFieldLabelAdapter, MDCTextFieldLineRippleAdapter, MDCTextFieldOutlineAdapter, MDCTextFieldRootAdapter} from '@material/textfield/adapter.js';
 import {MDCTextFieldCharacterCounterFoundation} from '@material/textfield/character-counter/foundation.js';
 import MDCTextFieldFoundation from '@material/textfield/foundation.js';
+import {html, property, PropertyValues, query, TemplateResult} from 'lit-element';
+import {classMap} from 'lit-html/directives/class-map';
 import {ifDefined} from 'lit-html/directives/if-defined.js';
 
 import {characterCounter, CharacterCounter} from './character-counter/mwc-character-counter-directive.js';

--- a/packages/textfield/src/mwc-textfield.ts
+++ b/packages/textfield/src/mwc-textfield.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {customElement} from '@material/mwc-base/form-element.js';
+import {customElement} from 'lit-element';
 import {TextFieldBase} from './mwc-textfield-base.js';
 import {style} from './mwc-textfield-css.js';
 

--- a/packages/top-app-bar-fixed/package.json
+++ b/packages/top-app-bar-fixed/package.json
@@ -19,6 +19,7 @@
     "@material/mwc-base": "^0.8.0",
     "@material/mwc-top-app-bar": "^0.8.0",
     "@material/top-app-bar": "^3.0.0",
+    "lit-element": "^2.2.1",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/top-app-bar-fixed/src/mwc-top-app-bar-fixed.ts
+++ b/packages/top-app-bar-fixed/src/mwc-top-app-bar-fixed.ts
@@ -14,8 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/base-element.js';
 import {style} from '@material/mwc-top-app-bar/mwc-top-app-bar-css';
+import {customElement} from 'lit-element';
 
 import {TopAppBarFixedBase} from './mwc-top-app-bar-fixed-base';
 

--- a/packages/top-app-bar/package.json
+++ b/packages/top-app-bar/package.json
@@ -18,6 +18,8 @@
   "dependencies": {
     "@material/mwc-base": "^0.8.0",
     "@material/top-app-bar": "^3.0.0",
+    "lit-element": "^2.2.1",
+    "lit-html": "^1.1.2",
     "tslib": "^1.10.0"
   },
   "publishConfig": {

--- a/packages/top-app-bar/src/mwc-top-app-bar-base-base.ts
+++ b/packages/top-app-bar/src/mwc-top-app-bar-base-base.ts
@@ -14,11 +14,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {addHasRemoveClass, BaseElement, classMap, html, property, query} from '@material/mwc-base/base-element';
+import {addHasRemoveClass, BaseElement} from '@material/mwc-base/base-element';
 import {supportsPassiveEventListener} from '@material/mwc-base/utils';
 import {MDCTopAppBarAdapter} from '@material/top-app-bar/adapter';
 import {strings} from '@material/top-app-bar/constants';
 import MDCTopAppBarBaseFoundation from '@material/top-app-bar/foundation';
+import {html, property, query} from 'lit-element';
+import {classMap} from 'lit-html/directives/class-map';
 
 export const passiveEventOptionsIfSupported =
     supportsPassiveEventListener ? {passive: true} : undefined;

--- a/packages/top-app-bar/src/mwc-top-app-bar-base.ts
+++ b/packages/top-app-bar/src/mwc-top-app-bar-base.ts
@@ -14,8 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {property} from '@material/mwc-base/base-element';
 import MDCTopAppBarFoundation from '@material/top-app-bar/standard/foundation';
+import {property} from 'lit-element';
 
 import {passiveEventOptionsIfSupported, TopAppBarBaseBase} from './mwc-top-app-bar-base-base';
 

--- a/packages/top-app-bar/src/mwc-top-app-bar.ts
+++ b/packages/top-app-bar/src/mwc-top-app-bar.ts
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {customElement} from '@material/mwc-base/base-element.js';
+import {customElement} from 'lit-element';
 
 import {TopAppBarBase} from './mwc-top-app-bar-base.js';
 import {style} from './mwc-top-app-bar-css.js';

--- a/sass-template.tmpl
+++ b/sass-template.tmpl
@@ -14,6 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {css} from '@material/mwc-base/base-element';
+import {css} from 'lit-element';
 
 export const style = css`<% content %>`;


### PR DESCRIPTION
Previously, `mwc-base` re-exported all of `lit-element` and part of `lit-html`. While that approach does make it a little easier to manage dependencies, it's better to include the dependency directly. Lerna can easily be used install/upgrade a dependency across all or a subset of packages.

- Users are likely to copy this style. We would prefer that if they use   lit, they directly depend on it, instead of depending on our base class   even when they may not need it.

- It locks us into using lit in our implementation without a breaking change. No plans to change that, but it's just one less thing in our API surface.

- It works better for internal Google tooling because the lit dependency can be analyzed statically.