### PR TITLE
Fixing mwc-icon import on mwc-textfiled readme

### DIFF
--- a/packages/textfield/README.md
+++ b/packages/textfield/README.md
@@ -48,7 +48,7 @@ npm install @material/mwc-textfield
 
 <script type="module">
   import '@material/mwc-textfield';
-  import '@material/mwc-icon/mwc-icon-font';
+  import '@material/mwc-icon';
 </script>
 ```
 


### PR DESCRIPTION
This PR proposal is to fix mwc-icon import on mwc-textfiled readme. It was based on this issue reported here: https://github.com/material-components/material-components-web-components/issues/86
