### PR TITLE
Provide variable to user for changing dialog padding

### DIFF
--- a/packages/dialog/mwc-dialog.scss
+++ b/packages/dialog/mwc-dialog.scss
@@ -93,13 +93,7 @@
   }
 
   .mdc-dialog__content {
-    @include mwc-dialog-padding(
-      dialog.$padding-top,
-      dialog.$padding-right,
-      dialog.$padding-bottom,
-      dialog.$padding-left,
-      $query: $query
-    );
+    @include mwc-dialog-padding(20px, 24px, 20px, 24px, $query: $query);
   }
 }
 

--- a/packages/dialog/mwc-dialog.scss
+++ b/packages/dialog/mwc-dialog.scss
@@ -91,6 +91,16 @@
       }
     }
   }
+
+  .mdc-dialog__content {
+    @include mwc-dialog-padding(
+      dialog.$padding-top,
+      dialog.$padding-right,
+      dialog.$padding-bottom,
+      dialog.$padding-left,
+      $query: $query
+    );
+  }
 }
 
 @mixin mwc-dialog-scrim-color(
@@ -196,6 +206,49 @@
         (
           varname: --mdc-dialog-min-width,
           fallback: $min-width,
+        )
+      );
+    }
+  }
+}
+
+@mixin mwc-dialog-padding(
+  $padding-top,
+  $padding-right,
+  $padding-bottom,
+  $padding-left,
+  $query: feature.all()
+) {
+  $feat-structure: feature.create-target($query, structure);
+
+  .mdc-dialog__content {
+    @include feature.targets($feat-structure) {
+      @include theme.property(
+        padding-top,
+        (
+          varname: --mdc-dialog-padding-top,
+          fallback: $padding-top,
+        )
+      );
+      @include theme.property(
+        padding-right,
+        (
+          varname: --mdc-dialog-padding-right,
+          fallback: $padding-right,
+        )
+      );
+      @include theme.property(
+        padding-bottom,
+        (
+          varname: --mdc-dialog-padding-bottom,
+          fallback: $padding-bottom,
+        )
+      );
+      @include theme.property(
+        padding-left,
+        (
+          varname: --mdc-dialog-padding-left,
+          fallback: $padding-left,
         )
       );
     }


### PR DESCRIPTION
I recently faced an [issue](https://github.com/material-components/material-web/issues/2660) that I wasn't able to change the padding of dialog due to shadow-root. So I create variables to change padding they are named as follows `--mdc-dialog-padding-top`, `--mdc-dialog-padding-right`, `--mdc-dialog-padding-bottom`, `--mdc-dialog-padding-left`.