### PR TITLE
fix(mwc-textfield): hide element if type is hidden

### DIFF
--- a/packages/textfield/mwc-textfield.scss
+++ b/packages/textfield/mwc-textfield.scss
@@ -28,6 +28,15 @@
   outline: none;
 }
 
+:host([type="hidden" i]) {
+  display: none;
+  appearance: none;
+  background-color: initial;
+  cursor: default;
+  padding: initial;
+  border: initial;
+}
+
 .mdc-text-field {
   width: 100%;
 


### PR DESCRIPTION
feel free to refactor or modify but I think the hidden style is neccessary to hide the element as a whole