### PR TITLE
More sass 1.41 compat fixes

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-          node-version: 10
+          node-version: 14
 
     - name: NPM install
       # Don't run postinstall because we don't need to install sub-packages.

--- a/.github/workflows/bump-mdc-deps.yml
+++ b/.github/workflows/bump-mdc-deps.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-          node-version: 10
+          node-version: 14
 
     - name: NPM install
       # Don't run postinstall because we don't need to install sub-packages.

--- a/.github/workflows/deploy-demos.yml
+++ b/.github/workflows/deploy-demos.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-            node-version: 10
+            node-version: 14
 
       - name: Install and Build
         run: |

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 10
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 12
+        node-version: 14
 
     - name: NPM install
       # ignore-scripts so that we skip postinstall, because postinstall runs
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 12
+        node-version: 14
 
     - name: NPM install
       # ignore-scripts so that we skip postinstall, because postinstall runs

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "rollup-plugin-copy": "^3.3.0",
     "rollup-plugin-minify-html-literals": "^1.2.3",
     "rollup-plugin-terser": "^5.3.0",
-    "sass": "^1.34.1",
+    "sass": "~1.34.1",
     "shady-css-parser": "^0.1.0",
     "tachometer": "^0.4.13",
     "typescript": "^4.3.5"

--- a/packages/button/_button.scss
+++ b/packages/button/_button.scss
@@ -225,14 +225,14 @@
 
   @include theme.property(
     padding-left,
-    calc(padding - outline),
+    'calc(padding - outline)',
     $gss: (noflip: true),
     $replace: $replace
   );
 
   @include theme.property(
     padding-right,
-    calc(padding - outline),
+    'calc(padding - outline)',
     $gss: (noflip: true),
     $replace: $replace
   );
@@ -243,9 +243,9 @@
     width: $width,
   );
 
-  @include theme.property(top, calc(-1 * width), $replace: $replace);
+  @include theme.property(top, 'calc(-1 * width)', $replace: $replace);
 
-  @include rtl.reflexive-position(left, calc(-1 * width), $replace: $replace);
+  @include rtl.reflexive-position(left, 'calc(-1 * width)', $replace: $replace);
 
   @include theme.property(border-width, $width);
   border-style: solid;


### PR DESCRIPTION
- Fixes some more spots where invalid `calc` syntax causes a compilation error after a Sass minor version bump to v1.41. See also https://github.com/material-components/material-components-web/pull/7393 and https://github.com/material-components/material-components-web/pull/7402 which fix the other spots.

- Until https://github.com/material-components/material-components-web/pull/7402 is published to NPM, we'll need to pin this repo's Sass version to `~1.34.1`, because this repo directly compiles sass files from the MDC packages.

- Also bumps the Node version in CI from 12 to 14, since 14 is now the active LTS version.