### PR TITLE
Migrate to new "lit" package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 /build
 /coverage
 .DS_Store
+.*.sw[nop]
 /lerna-debug.log
 /gh-pages
 /packages/**/*.js

--- a/demos/card.html
+++ b/demos/card.html
@@ -48,7 +48,7 @@ limitations under the License.
   <script type="module">
     import {style as cardStyle} from '../node_modules/@material/mwc-card/mwc-card-css.js';
     import {style as typographyStyle} from '../node_modules/@material/mwc-typography/mwc-typography-css.js';
-    import {LitElement, html} from '../node_modules/lit-element/lit-element.js';
+    import {LitElement, html} from '../node_modules/lit/index.js';
     import '../node_modules/@material/mwc-button/mwc-button.js';
     import '../node_modules/@material/mwc-icon/mwc-icon.js';
     import '../node_modules/@material/mwc-icon-toggle/mwc-icon-toggle.js';

--- a/demos/elevation-overlay/index.js
+++ b/demos/elevation-overlay/index.js
@@ -15,8 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import {style as elevationStyle} from '@material/mwc-elevation-overlay/mwc-elevation-overlay-css';
-import {LitElement, css, html} from 'lit-element';
-import {styleMap} from 'lit-html/directives/style-map';
+import {LitElement, css, html} from 'lit';
+import {styleMap} from 'lit/directives/style-map.js';
 
 import '../shared/demo-header';
 

--- a/demos/index.js
+++ b/demos/index.js
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {LitElement, html, css} from 'lit-element/lit-element.js';
+import {LitElement, html, css} from 'lit';
 import '@material/mwc-list';
 import '@material/mwc-list/mwc-list-item';
 

--- a/demos/shared/demo-header.js
+++ b/demos/shared/demo-header.js
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {LitElement, html, css} from 'lit-element/lit-element.js';
+import {LitElement, html, css} from 'lit';
 import '@material/mwc-top-app-bar-fixed';
 import '@material/mwc-icon-button';
 import '@material/mwc-button';

--- a/packages/base/aria-property.ts
+++ b/packages/base/aria-property.ts
@@ -35,7 +35,7 @@ function tsDecorator(
       (prototype.constructor as unknown as ReactiveElementInternals);
   if (!descriptor) {
     /**
-     * lit-element uses internal properties with two leading underscores to
+     * lit uses internal properties with two leading underscores to
      * provide storage for accessors
      */
     const litInternalPropertyKey = `__${name}`;

--- a/packages/radio/mwc-radio-base.ts
+++ b/packages/radio/mwc-radio-base.ts
@@ -165,7 +165,7 @@ export class RadioBase extends FormElement {
     super.connectedCallback();
     // Note that we must defer creating the selection controller until the
     // element has connected, because selection controllers are keyed by the
-    // radio's shadow root. For example, if we're stamping in a lit-html map
+    // radio's shadow root. For example, if we're stamping in a lit map
     // or repeat, then we'll be constructed before we're added to a root node.
     //
     // Also note if we aren't using native shadow DOM, we still need a

--- a/packages/snackbar/accessible-snackbar-label-directive.ts
+++ b/packages/snackbar/accessible-snackbar-label-directive.ts
@@ -95,7 +95,7 @@ class AccessibleSnackbarLabel extends AsyncDirective {
     // all browsers and screen readers:
     //
     //   1. `textContent = ''` is required for IE11 + JAWS
-    //   2. the lit-html render of `'&nbsp;'` is required for Chrome + JAWS and
+    //   2. the lit render of `'&nbsp;'` is required for Chrome + JAWS and
     //       NVDA
     //
     // All other browser/screen reader combinations support both methods.

--- a/scripts/publish-demos.sh
+++ b/scripts/publish-demos.sh
@@ -30,7 +30,7 @@ cat <<-EOF >gh-pages/package.json
   "name": "demos",
   "private": true,
   "dependencies": {
-    "lit-element": "^2.0.0",
+    "lit": "^2.0.0",
     "@webcomponents/webcomponentsjs": "^2.0.0"
   }
 }

--- a/scripts/sass-to-lit-css/template.tmpl
+++ b/scripts/sass-to-lit-css/template.tmpl
@@ -3,5 +3,5 @@
  * Copyright 2021 Google LLC
  * SPDX-LIcense-Identifier: Apache-2.0
  */
-import {css} from 'lit-element';
+import {css} from 'lit';
 export const styles = css`<% content %>`;

--- a/test/src/benchmark/button/test-basic.ts
+++ b/test/src/benchmark/button/test-basic.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import '@material/mwc-button';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/checkbox/test-basic.ts
+++ b/test/src/benchmark/checkbox/test-basic.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import '@material/mwc-checkbox';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/drawer/test-basic.ts
+++ b/test/src/benchmark/drawer/test-basic.ts
@@ -16,7 +16,7 @@ limitations under the License.
 */
 import '@material/mwc-drawer';
 import '@material/mwc-top-app-bar';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/fab/test-basic.ts
+++ b/test/src/benchmark/fab/test-basic.ts
@@ -16,7 +16,7 @@ limitations under the License.
 */
 import '@material/mwc-fab';
 import '@material/mwc-icon';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/formfield/test-basic.ts
+++ b/test/src/benchmark/formfield/test-basic.ts
@@ -16,7 +16,7 @@ limitations under the License.
 */
 import '@material/mwc-formfield';
 import '@material/mwc-radio';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/icon-button/test-basic.ts
+++ b/test/src/benchmark/icon-button/test-basic.ts
@@ -16,7 +16,7 @@ limitations under the License.
 */
 import '@material/mwc-icon-button';
 import '@material/mwc-icon';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/icon/test-basic.ts
+++ b/test/src/benchmark/icon/test-basic.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import '@material/mwc-icon';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/linear-progress/test-basic.ts
+++ b/test/src/benchmark/linear-progress/test-basic.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import '@material/mwc-linear-progress';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/list-item/basic.ts
+++ b/test/src/benchmark/list-item/basic.ts
@@ -16,7 +16,7 @@
  */
 import '@material/mwc-list/mwc-list-item';
 
-import {html} from 'lit-html';
+import {html} from 'lit';
 
 import {measureFixtureCreation} from '../../util/helpers';
 

--- a/test/src/benchmark/list/basic.ts
+++ b/test/src/benchmark/list/basic.ts
@@ -19,7 +19,7 @@ import '@material/mwc-list/mwc-list-item';
 
 import {List} from '@material/mwc-list';
 import {ListItem} from '@material/mwc-list/mwc-list-item';
-import {html} from 'lit-html';
+import {html} from 'lit';
 
 import {measureFixtureCreation} from '../../util/helpers';
 

--- a/test/src/benchmark/menu/basic.ts
+++ b/test/src/benchmark/menu/basic.ts
@@ -19,7 +19,7 @@ import '@material/mwc-list/mwc-list-item';
 
 import {ListItem} from '@material/mwc-list/mwc-list-item';
 import {Menu} from '@material/mwc-menu';
-import {html} from 'lit-html';
+import {html} from 'lit';
 
 import {measureFixtureCreation} from '../../util/helpers';
 

--- a/test/src/benchmark/radio/test-basic.ts
+++ b/test/src/benchmark/radio/test-basic.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import '@material/mwc-radio';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/ripple/test-basic.ts
+++ b/test/src/benchmark/ripple/test-basic.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import '@material/mwc-ripple/mwc-ripple';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/select/basic.ts
+++ b/test/src/benchmark/select/basic.ts
@@ -19,7 +19,7 @@ import '@material/mwc-list/mwc-list-item';
 
 import {ListItem} from '@material/mwc-list/mwc-list-item';
 import {Select} from '@material/mwc-select';
-import {html} from 'lit-html';
+import {html} from 'lit';
 
 import {measureFixtureCreation} from '../../util/helpers';
 

--- a/test/src/benchmark/slider/test-basic.ts
+++ b/test/src/benchmark/slider/test-basic.ts
@@ -16,7 +16,7 @@ limitations under the License.
 */
 import '@material/mwc-slider';
 import '@material/mwc-checkbox';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/snackbar/test-basic.ts
+++ b/test/src/benchmark/snackbar/test-basic.ts
@@ -17,7 +17,7 @@ limitations under the License.
 import '@material/mwc-snackbar';
 import '@material/mwc-checkbox';
 
-import {html} from 'lit-html';
+import {html} from 'lit';
 
 import {measureFixtureCreation} from '../../util/helpers';
 

--- a/test/src/benchmark/switch/test-basic.ts
+++ b/test/src/benchmark/switch/test-basic.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import '@material/mwc-switch';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/tab-bar/test-basic.ts
+++ b/test/src/benchmark/tab-bar/test-basic.ts
@@ -16,7 +16,7 @@ limitations under the License.
 */
 import '@material/mwc-tab-bar';
 import '@material/mwc-tab';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/tab/test-basic.ts
+++ b/test/src/benchmark/tab/test-basic.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import '@material/mwc-tab';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/textfield/basic.ts
+++ b/test/src/benchmark/textfield/basic.ts
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import '@material/mwc-textfield/mwc-textfield';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`

--- a/test/src/benchmark/top-app-bar/test-basic.ts
+++ b/test/src/benchmark/top-app-bar/test-basic.ts
@@ -16,7 +16,7 @@ limitations under the License.
 */
 import '@material/mwc-top-app-bar';
 import '@material/mwc-icon-button';
-import {html} from 'lit-html';
+import {html} from 'lit';
 import {measureFixtureCreation} from '../../util/helpers';
 
 measureFixtureCreation(html`


### PR DESCRIPTION
This changes usages of `lit-element` and `lit-html` to the new `lit` npm package. Before this change, downstream Typescript users get a deprecation warning due to the use of `lit-element` in CSS type declarations.

I went ahead and migrated demo and test scripts as well, though I don't think those impact users.