### PR TITLE
fix(mwc-icon-button) Fix alignment when slot is used

### DIFF
--- a/packages/icon-button/mwc-icon-button-base.ts
+++ b/packages/icon-button/mwc-icon-button-base.ts
@@ -85,7 +85,7 @@ export class IconButtonBase extends LitElement {
         @touchend="${this.handleRippleDeactivate}"
         @touchcancel="${this.handleRippleDeactivate}"
     >${this.renderRipple()}
-    ${this.icon ? html`<i class="material-icons">${this.icon}</i>` : ""}
+    ${this.icon ? html`<i class="material-icons">${this.icon}</i>` : ''}
     <span
       ><slot></slot
     ></span>

--- a/packages/icon-button/mwc-icon-button-base.ts
+++ b/packages/icon-button/mwc-icon-button-base.ts
@@ -85,7 +85,7 @@ export class IconButtonBase extends LitElement {
         @touchend="${this.handleRippleDeactivate}"
         @touchcancel="${this.handleRippleDeactivate}"
     >${this.renderRipple()}
-    <i class="material-icons">${this.icon}</i>
+    ${this.icon ? html`<i class="material-icons">${this.icon}</i>` : ""}
     <span
       ><slot></slot
     ></span>


### PR DESCRIPTION
Since flex is now used for alignment, the `i` element, that is always rendered even when not used, now messes the alignment up when the `slot` is used.

![image](https://user-images.githubusercontent.com/5662298/137593169-268beab0-8cb5-43ef-aa8e-72873d32b1de.png)

This PR fixes that by not rendering the `i` element when it is not used.