### PR TITLE
Adding part attribute to elements

### DIFF
--- a/packages/button/mwc-button-base.ts
+++ b/packages/button/mwc-button-base.ts
@@ -108,6 +108,7 @@ export class ButtonBase extends LitElement {
     return html`
       <button
           id="button"
+          part="button"
           class="mdc-button ${classMap(this.getRenderClasses())}"
           ?disabled="${this.disabled}"
           aria-label="${this.label || this.icon}"
@@ -122,18 +123,18 @@ export class ButtonBase extends LitElement {
           @touchcancel="${this.handleRippleDeactivate}">
         ${this.renderOverlay()}
         ${this.renderRipple()}
-        <span class="leading-icon">
+        <span class="leading-icon" part="leading-icon">
           <slot name="icon">
             ${this.icon && !this.trailingIcon ? this.renderIcon() : ''}
           </slot>
         </span>
-        <span class="mdc-button__label">${this.label}</span>
+        <span class="mdc-button__label" part="label">${this.label}</span>
         <span class="slot-container ${classMap({
       flex: this.expandContent
-    })}">
+    })}" part="slot-container">
           <slot></slot>
         </span>
-        <span class="trailing-icon">
+        <span class="trailing-icon" part="trailing-icon">
           <slot name="trailingIcon">
             ${this.icon && this.trailingIcon ? this.renderIcon() : ''}
           </slot>
@@ -144,7 +145,7 @@ export class ButtonBase extends LitElement {
   /** @soyTemplate */
   protected renderIcon(): TemplateResult {
     return html`
-    <mwc-icon class="mdc-button__icon">
+    <mwc-icon class="mdc-button__icon" part="icon">
       ${this.icon}
     </mwc-icon>`;
   }

--- a/packages/checkbox/mwc-checkbox-base.ts
+++ b/packages/checkbox/mwc-checkbox-base.ts
@@ -155,9 +155,10 @@ export class CheckboxBase extends FormElement {
     /* eslint-enable eqeqeq */
     const ariaChecked = this.indeterminate ? 'mixed' : undefined;
     return html`
-      <div class="mdc-checkbox mdc-checkbox--upgraded ${classMap(classes)}">
+      <div class="mdc-checkbox mdc-checkbox--upgraded ${classMap(classes)}" part="checkbox">
         <input type="checkbox"
               class="mdc-checkbox__native-control"
+              part="native-control"
               name="${ifDefined(this.name)}"
               aria-checked="${ifDefined(ariaChecked)}"
               aria-label="${ifDefined(this.ariaLabel)}"
@@ -177,15 +178,15 @@ export class CheckboxBase extends FormElement {
               @touchstart="${this.handleRippleTouchStart}"
               @touchend="${this.handleRippleDeactivate}"
               @touchcancel="${this.handleRippleDeactivate}">
-        <div class="mdc-checkbox__background"
+        <div class="mdc-checkbox__background" part="background"
           @animationend="${this.resetAnimationClass}">
-          <svg class="mdc-checkbox__checkmark"
+          <svg class="mdc-checkbox__checkmark" part="checkmark"
               viewBox="0 0 24 24">
             <path class="mdc-checkbox__checkmark-path"
                   fill="none"
                   d="M1.73,12.91 8.1,19.28 22.79,4.59"></path>
           </svg>
-          <div class="mdc-checkbox__mixedmark"></div>
+          <div class="mdc-checkbox__mixedmark" part="mixedmark"></div>
         </div>
         ${this.renderRipple()}
       </div>`;

--- a/packages/circular-progress-four-color/mwc-circular-progress-four-color-base.ts
+++ b/packages/circular-progress-four-color/mwc-circular-progress-four-color-base.ts
@@ -15,17 +15,17 @@ export class CircularProgressFourColorBase extends CircularProgressBase {
   /** @soyTemplate */
   protected override renderIndeterminateContainer(): TemplateResult {
     return html`
-      <div class="mdc-circular-progress__indeterminate-container">
-        <div class="mdc-circular-progress__spinner-layer mdc-circular-progress__color-1">
+      <div class="mdc-circular-progress__indeterminate-container" part="indeterminate-container">
+        <div class="mdc-circular-progress__spinner-layer mdc-circular-progress__color-1" part="color-1">
           ${this.renderIndeterminateSpinnerLayer()}
         </div>
-        <div class="mdc-circular-progress__spinner-layer mdc-circular-progress__color-2">
+        <div class="mdc-circular-progress__spinner-layer mdc-circular-progress__color-2" part="color-2">
           ${this.renderIndeterminateSpinnerLayer()}
         </div>
-        <div class="mdc-circular-progress__spinner-layer mdc-circular-progress__color-3">
+        <div class="mdc-circular-progress__spinner-layer mdc-circular-progress__color-3" part="color-3">
           ${this.renderIndeterminateSpinnerLayer()}
         </div>
-        <div class="mdc-circular-progress__spinner-layer mdc-circular-progress__color-4">
+        <div class="mdc-circular-progress__spinner-layer mdc-circular-progress__color-4" part="color-4">
           ${this.renderIndeterminateSpinnerLayer()}
         </div>
       </div>`;

--- a/packages/circular-progress/mwc-circular-progress-base.ts
+++ b/packages/circular-progress/mwc-circular-progress-base.ts
@@ -57,6 +57,7 @@ export class CircularProgressBase extends LitElement {
     return html`
       <div
         class="mdc-circular-progress ${classMap(classes)}"
+        part="circular-progress"
         style="${styleMap(styles)}"
         role="progressbar"
         aria-label="${ifDefined(this.ariaLabel)}"
@@ -83,13 +84,13 @@ export class CircularProgressBase extends LitElement {
                                              3 + (this.density + 3) * (1 / 6);
 
     return html`
-      <div class="mdc-circular-progress__determinate-container">
-        <svg class="mdc-circular-progress__determinate-circle-graphic"
+      <div class="mdc-circular-progress__determinate-container" part="determinate-container">
+        <svg class="mdc-circular-progress__determinate-circle-graphic" part="determinate-circle-graphic"
              viewBox="0 0 ${sideLength} ${sideLength}">
-          <circle class="mdc-circular-progress__determinate-track"
+          <circle class="mdc-circular-progress__determinate-track" part="determinate-track"
                   cx="${center}" cy="${center}" r="${circleRadius}"
                   stroke-width="${strokeWidth}"></circle>
-          <circle class="mdc-circular-progress__determinate-circle"
+          <circle class="mdc-circular-progress__determinate-circle" part="determinate-circle"
                   cx="${center}" cy="${center}" r="${circleRadius}"
                   stroke-dasharray="${2 * 3.1415926 * circleRadius}"
                   stroke-dashoffset="${determinateStrokeDashOffset}"
@@ -103,8 +104,8 @@ export class CircularProgressBase extends LitElement {
    */
   protected renderIndeterminateContainer(): TemplateResult {
     return html`
-      <div class="mdc-circular-progress__indeterminate-container">
-        <div class="mdc-circular-progress__spinner-layer">
+      <div class="mdc-circular-progress__indeterminate-container" part="indeterminate-container">
+        <div class="mdc-circular-progress__spinner-layer" part="spinner-layer">
           ${this.renderIndeterminateSpinnerLayer()}
         </div>
       </div>`;
@@ -124,8 +125,8 @@ export class CircularProgressBase extends LitElement {
                                              3 + (this.density + 3) * (1 / 6);
 
     return html`
-        <div class="mdc-circular-progress__circle-clipper mdc-circular-progress__circle-left">
-          <svg class="mdc-circular-progress__indeterminate-circle-graphic"
+        <div class="mdc-circular-progress__circle-clipper mdc-circular-progress__circle-left" part="circle-left">
+          <svg class="mdc-circular-progress__indeterminate-circle-graphic" part="indeterminate-circle-graphic"
                viewBox="0 0 ${sideLength} ${sideLength}">
             <circle cx="${center}" cy="${center}" r="${circleRadius}"
                     stroke-dasharray="${circumference}"
@@ -133,8 +134,8 @@ export class CircularProgressBase extends LitElement {
                     stroke-width="${strokeWidth}"></circle>
           </svg>
         </div>
-        <div class="mdc-circular-progress__gap-patch">
-          <svg class="mdc-circular-progress__indeterminate-circle-graphic"
+        <div class="mdc-circular-progress__gap-patch" part="gap-patch">
+          <svg class="mdc-circular-progress__indeterminate-circle-graphic" part="indeterminate-circle-graphic"
                viewBox="0 0 ${sideLength} ${sideLength}">
             <circle cx="${center}" cy="${center}" r="${circleRadius}"
                     stroke-dasharray="${circumference}"
@@ -142,8 +143,8 @@ export class CircularProgressBase extends LitElement {
                     stroke-width="${strokeWidth * 0.8}"></circle>
           </svg>
         </div>
-        <div class="mdc-circular-progress__circle-clipper mdc-circular-progress__circle-right">
-          <svg class="mdc-circular-progress__indeterminate-circle-graphic"
+        <div class="mdc-circular-progress__circle-clipper mdc-circular-progress__circle-right" part="circle-right">
+          <svg class="mdc-circular-progress__indeterminate-circle-graphic" part="indeterminate-circle-graphic"
                viewBox="0 0 ${sideLength} ${sideLength}">
             <circle cx="${center}" cy="${center}" r="${circleRadius}"
                     stroke-dasharray="${circumference}"

--- a/packages/dialog/mwc-dialog-base.ts
+++ b/packages/dialog/mwc-dialog-base.ts
@@ -296,20 +296,20 @@ export class DialogBase extends BaseElement {
     };
 
     return html`
-    <div class="mdc-dialog ${classMap(classes)}"
+    <div class="mdc-dialog ${classMap(classes)}" part="dialog"
         role="alertdialog"
         aria-modal="true"
         aria-labelledby="title"
         aria-describedby="content">
-      <div class="mdc-dialog__container">
-        <div class="mdc-dialog__surface">
+      <div class="mdc-dialog__container" part="container">
+        <div class="mdc-dialog__surface" part="surface">
           ${heading}
-          <div id="content" class="mdc-dialog__content">
+          <div id="content" class="mdc-dialog__content" part="content">
             <slot id="contentSlot"></slot>
           </div>
           <footer
               id="actions"
-              class="${classMap(actionsClasses)}">
+              class="${classMap(actionsClasses)}" part="actions">
             <span>
               <slot name="secondaryAction"></slot>
             </span>
@@ -319,13 +319,13 @@ export class DialogBase extends BaseElement {
           </footer>
         </div>
       </div>
-      <div class="mdc-dialog__scrim"></div>
+      <div class="mdc-dialog__scrim" part="scrim"></div>
     </div>`;
   }
 
   protected renderHeading() {
     return html`
-      <h2 id="title" class="mdc-dialog__title">${this.heading}</h2>`;
+      <h2 id="title" class="mdc-dialog__title" part="title">${this.heading}</h2>`;
   }
 
   protected override firstUpdated() {

--- a/packages/drawer/mwc-drawer-base.ts
+++ b/packages/drawer/mwc-drawer-base.ts
@@ -114,9 +114,9 @@ export class DrawerBase extends BaseElement {
     const dismissible = this.type === 'dismissible' || this.type === 'modal';
     const modal = this.type === 'modal';
     const header = this.hasHeader ? html`
-      <div class="mdc-drawer__header">
-        <h3 class="mdc-drawer__title"><slot name="title"></slot></h3>
-        <h6 class="mdc-drawer__subtitle"><slot name="subtitle"></slot></h6>
+      <div class="mdc-drawer__header" part="header">
+        <h3 class="mdc-drawer__title" part="title"><slot name="title"></slot></h3>
+        <h6 class="mdc-drawer__subtitle" part="subtitle"><slot name="subtitle"></slot></h6>
         <slot name="header"></slot>
       </div>
       ` :
@@ -127,15 +127,15 @@ export class DrawerBase extends BaseElement {
     };
 
     return html`
-      <aside class="mdc-drawer ${classMap(classes)}">
+      <aside class="mdc-drawer ${classMap(classes)}" part="drawer">
         ${header}
-        <div class="mdc-drawer__content"><slot></slot></div>
+        <div class="mdc-drawer__content" part="content"><slot></slot></div>
       </aside>
       ${
-        modal ? html`<div class="mdc-drawer-scrim"
+        modal ? html`<div class="mdc-drawer-scrim" part="scrim"
                           @click="${this._handleScrimClick}"></div>` :
                 ''}
-      <div class="mdc-drawer-app-content">
+      <div class="mdc-drawer-app-content" part="app-content">
         <slot name="appContent"></slot>
       </div>
       `;

--- a/packages/fab/mwc-fab-base.ts
+++ b/packages/fab/mwc-fab-base.ts
@@ -73,6 +73,7 @@ export class FabBase extends LitElement {
      */
     return html`<button
           class="mdc-fab ${classMap(classes)}"
+          part="fab"
           ?disabled="${this.disabled}"
           aria-label="${ariaLabel}"
           @mouseenter=${this.handleRippleMouseEnter}
@@ -86,7 +87,7 @@ export class FabBase extends LitElement {
         -->${this.renderBeforeRipple()}<!--
         -->${this.renderRipple()}<!--
         -->${this.showIconAtEnd ? this.renderLabel() : ''}<!--
-        --><span class="material-icons mdc-fab__icon"><!--
+        --><span class="material-icons mdc-fab__icon" part="icon"><!--
           --><slot name="icon">${this.icon}</slot><!--
        --></span><!--
         -->${!this.showIconAtEnd ? this.renderLabel() : ''}<!--
@@ -105,7 +106,7 @@ export class FabBase extends LitElement {
     const hasTouchTarget = this.mini && !this.reducedTouchTarget;
 
     return html`${
-        hasTouchTarget ? html`<div class="mdc-fab__touch"></div>` : ''}`;
+        hasTouchTarget ? html`<div class="mdc-fab__touch" part="touch"></div>` : ''}`;
   }
 
   /** @soyTemplate */
@@ -113,7 +114,7 @@ export class FabBase extends LitElement {
     const showLabel = this.label !== '' && this.extended;
 
     return html`${
-        showLabel ? html`<span class="mdc-fab__label">${this.label}</span>` :
+        showLabel ? html`<span class="mdc-fab__label" part="label">${this.label}</span>` :
                     ''}`;
   }
 

--- a/packages/formfield/mwc-formfield-base.ts
+++ b/packages/formfield/mwc-formfield-base.ts
@@ -84,9 +84,9 @@ export class FormfieldBase extends BaseElement {
     };
 
     return html`
-      <div class="mdc-form-field ${classMap(classes)}">
+      <div class="mdc-form-field ${classMap(classes)}" part="form-field">
         <slot></slot>
-        <label class="mdc-label"
+        <label class="mdc-label" part="label"
                @click="${this._labelClick}">${this.label}</label>
       </div>`;
   }

--- a/packages/icon-button-toggle/mwc-icon-button-toggle-base.ts
+++ b/packages/icon-button-toggle/mwc-icon-button-toggle-base.ts
@@ -95,6 +95,7 @@ export class IconButtonToggleBase extends LitElement {
     return html`<button
           class="mdc-icon-button mdc-icon-button--display-flex ${
         classMap(classes)}"
+          part="icon-button"
           aria-pressed="${ifDefined(ariaPressedValue)}"
           aria-label="${ifDefined(ariaLabelValue)}"
           @click="${this.handleClick}"
@@ -108,14 +109,14 @@ export class IconButtonToggleBase extends LitElement {
           @touchend="${this.handleRippleDeactivate}"
           @touchcancel="${this.handleRippleDeactivate}"
         >${this.renderRipple()}
-        <span class="mdc-icon-button__icon"
+        <span class="mdc-icon-button__icon" part="icon"
           ><slot name="offIcon"
-            ><i class="material-icons">${this.offIcon}</i
+            ><i class="material-icons" part="material-icons-off">${this.offIcon}</i
           ></slot
         ></span>
-        <span class="mdc-icon-button__icon mdc-icon-button__icon--on"
+        <span class="mdc-icon-button__icon mdc-icon-button__icon--on" part="icon-button-on"
           ><slot name="onIcon"
-            ><i class="material-icons">${this.onIcon}</i
+            ><i class="material-icons" part="material-icons-on">${this.onIcon}</i
           ></slot
         ></span>
       </button>`;

--- a/packages/icon-button/mwc-icon-button-base.ts
+++ b/packages/icon-button/mwc-icon-button-base.ts
@@ -73,6 +73,7 @@ export class IconButtonBase extends LitElement {
   protected override render(): TemplateResult {
     return html`<button
         class="mdc-icon-button mdc-icon-button--display-flex"
+        part="icon-button"
         aria-label="${this.ariaLabel || this.icon}"
         aria-haspopup="${ifDefined(this.ariaHasPopup)}"
         ?disabled="${this.disabled}"
@@ -85,7 +86,7 @@ export class IconButtonBase extends LitElement {
         @touchend="${this.handleRippleDeactivate}"
         @touchcancel="${this.handleRippleDeactivate}"
     >${this.renderRipple()}
-    ${this.icon ? html`<i class="material-icons">${this.icon}</i>` : ''}
+    ${this.icon ? html`<i class="material-icons" part="material-icons">${this.icon}</i>` : ''}
     <span
       ><slot></slot
     ></span>

--- a/packages/icon/mwc-icon.ts
+++ b/packages/icon/mwc-icon.ts
@@ -19,7 +19,7 @@ export class Icon extends LitElement {
 
   /** @soyTemplate */
   protected override render(): TemplateResult {
-    return html`<span><slot></slot></span>`;
+    return html`<span part="icon"><slot></slot></span>`;
   }
 }
 

--- a/packages/linear-progress/mwc-linear-progress-base.ts
+++ b/packages/linear-progress/mwc-linear-progress-base.ts
@@ -98,6 +98,7 @@ export class LinearProgressBase extends LitElement {
       <div
           role="progressbar"
           class="mdc-linear-progress ${classMap(classes)}"
+          part="linear-progress"
           style="${styleMap(rootStyles)}"
           dir="${ifDefined(this.reverse ? 'rtl' : undefined)}"
           aria-label="${ifDefined(this.ariaLabel)}"
@@ -106,20 +107,24 @@ export class LinearProgressBase extends LitElement {
           aria-valuenow="${
         ifDefined(this.indeterminate ? undefined : this.progress)}"
         @transitionend="${this.syncClosedState}">
-        <div class="mdc-linear-progress__buffer">
+        <div class="mdc-linear-progress__buffer" part="buffer">
           <div
             class="mdc-linear-progress__buffer-bar"
+            part="buffer-bar"
             style=${styleMap(bufferBarStyles)}>
           </div>
-          <div class="mdc-linear-progress__buffer-dots"></div>
+          <div class="mdc-linear-progress__buffer-dots" part="buffer-dots></div>
         </div>
         <div
             class="mdc-linear-progress__bar mdc-linear-progress__primary-bar"
+            part="primary-bar"
             style=${styleMap(primaryBarStyles)}>
-          <span class="mdc-linear-progress__bar-inner"></span>
+          <span class="mdc-linear-progress__bar-inner" part="primary-bar-inner"></span>
         </div>
-        <div class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar">
-          <span class="mdc-linear-progress__bar-inner"></span>
+        <div
+            class="mdc-linear-progress__bar mdc-linear-progress__secondary-bar"
+            part="secondary-bar">
+          <span class="mdc-linear-progress__bar-inner" part="secondary-bar-inner"></span>
         </div>
       </div>`;
   }

--- a/packages/list/mwc-check-list-item-base.ts
+++ b/packages/list/mwc-check-list-item-base.ts
@@ -42,9 +42,10 @@ export class CheckListItemBase extends ListItemBase {
       ${ripple}
       ${graphic}
       ${this.left ? '' : text}
-      <span class=${classMap(checkboxClasses)}>
+      <span class=${classMap(checkboxClasses)} part="list-item">
         <mwc-checkbox
             reducedTouchTarget
+            part="mwc-checkbox"
             tabindex=${this.tabindex}
             .checked=${this.selected}
             ?disabled=${this.disabled}

--- a/packages/list/mwc-list-base.ts
+++ b/packages/list/mwc-list-base.ts
@@ -248,6 +248,7 @@ export abstract class ListBase extends BaseElement implements Layoutable {
           role="${ifDefined(role)}"
           aria-label="${ifDefined(ariaLabel)}"
           class="mdc-deprecated-list"
+          part="list"
           @keydown=${this.onKeydown}
           @focusin=${this.onFocusIn}
           @focusout=${this.onFocusOut}

--- a/packages/list/mwc-list-item-base.ts
+++ b/packages/list/mwc-list-item-base.ts
@@ -173,7 +173,7 @@ export class ListItemBase extends LitElement {
         .activated=${this.activated}>
       </mwc-ripple>`;
     } else if (this.activated) {
-      return html`<div class="fake-activated-ripple"></div>`;
+      return html`<div class="fake-activated-ripple" part="fake-activated-ripple"></div>`;
     } else {
       return '';
     }
@@ -186,14 +186,15 @@ export class ListItemBase extends LitElement {
 
     return html`
       <span class="mdc-deprecated-list-item__graphic material-icons ${
-        classMap(graphicClasses)}">
+        classMap(graphicClasses)}" part="list-item-graphic">
         <slot name="graphic"></slot>
       </span>`;
   }
 
   protected renderMeta() {
     return html`
-      <span class="mdc-deprecated-list-item__meta material-icons">
+      <span class="mdc-deprecated-list-item__meta material-icons"
+          part="list-item-meta">
         <slot name="meta"></slot>
       </span>`;
   }
@@ -201,7 +202,7 @@ export class ListItemBase extends LitElement {
   protected renderText() {
     const inner = this.twoline ? this.renderTwoline() : this.renderSingleLine();
     return html`
-      <span class="mdc-deprecated-list-item__text">
+      <span class="mdc-deprecated-list-item__text" part="list-item-text">
         ${inner}
       </span>`;
   }
@@ -212,10 +213,10 @@ export class ListItemBase extends LitElement {
 
   protected renderTwoline() {
     return html`
-      <span class="mdc-deprecated-list-item__primary-text">
+      <span class="mdc-deprecated-list-item__primary-text" part="primary-text">
         <slot></slot>
       </span>
-      <span class="mdc-deprecated-list-item__secondary-text">
+      <span class="mdc-deprecated-list-item__secondary-text" part="secondary-text">
         <slot name="secondary"></slot>
       </span>
     `;

--- a/packages/notched-outline/mwc-notched-outline-base.ts
+++ b/packages/notched-outline/mwc-notched-outline-base.ts
@@ -59,12 +59,12 @@ export class NotchedOutlineBase extends BaseElement {
     });
 
     return html`
-      <span class="mdc-notched-outline ${classes}">
-        <span class="mdc-notched-outline__leading"></span>
-        <span class="mdc-notched-outline__notch">
+      <span class="mdc-notched-outline ${classes}" part="notched-outline">
+        <span class="mdc-notched-outline__leading" part="leading"></span>
+        <span class="mdc-notched-outline__notch" part="notch">
           <slot></slot>
         </span>
-        <span class="mdc-notched-outline__trailing"></span>
+        <span class="mdc-notched-outline__trailing" part="trailing"></span>
       </span>`;
   }
 }

--- a/packages/radio/mwc-radio-base.ts
+++ b/packages/radio/mwc-radio-base.ts
@@ -244,10 +244,11 @@ export class RadioBase extends FormElement {
     };
 
     return html`
-      <div class="mdc-radio ${classMap(classes)}">
+      <div class="mdc-radio ${classMap(classes)}" part="radio">
         <input
           tabindex="${this.formElementTabIndex}"
           class="mdc-radio__native-control"
+          part="native-control"
           type="radio"
           name="${this.name}"
           aria-label="${ifDefined(this.ariaLabel)}"
@@ -265,9 +266,9 @@ export class RadioBase extends FormElement {
           @touchstart="${this.handleRippleTouchStart}"
           @touchend="${this.handleRippleDeactivate}"
           @touchcancel="${this.handleRippleDeactivate}">
-        <div class="mdc-radio__background">
-          <div class="mdc-radio__outer-circle"></div>
-          <div class="mdc-radio__inner-circle"></div>
+        <div class="mdc-radio__background" part="background">
+          <div class="mdc-radio__outer-circle" part="outer-circle"></div>
+          <div class="mdc-radio__inner-circle" part="inner-circle"></div>
         </div>
         ${this.renderRipple()}
       </div>`;

--- a/packages/ripple/mwc-ripple-base.ts
+++ b/packages/ripple/mwc-ripple-base.ts
@@ -219,6 +219,7 @@ export class RippleBase extends BaseElement implements RippleInterface {
     };
     return html`
         <div class="mdc-ripple-surface mdc-ripple-upgraded ${classMap(classes)}"
+          part="ripple"
           style="${styleMap({
       '--mdc-ripple-fg-scale': this.fgScale,
       '--mdc-ripple-fg-size': this.fgSize,

--- a/packages/select/mwc-select-base.ts
+++ b/packages/select/mwc-select-base.ts
@@ -262,9 +262,11 @@ export abstract class SelectBase extends FormElement {
 
     return html`
       <div
-          class="mdc-select ${classMap(classes)}">
+          class="mdc-select ${classMap(classes)}"
+          part="select">
         <input
             class="formElement"
+            part="form-element"
             name="${this.name}"
             .value="${this.value}"
             hidden
@@ -272,6 +274,7 @@ export abstract class SelectBase extends FormElement {
             ?required=${this.required}>
         <!-- @ts-ignore -->
         <div class="mdc-select__anchor"
+            part="anchor"
             aria-autocomplete="none"
             role="combobox"
             aria-expanded=${this.menuOpen}
@@ -287,22 +290,25 @@ export abstract class SelectBase extends FormElement {
           ${this.renderRipple()}
           ${this.outlined ? this.renderOutline() : this.renderLabel()}
           ${this.renderLeadingIcon()}
-          <span class="mdc-select__selected-text-container">
-            <span class="mdc-select__selected-text">${this.selectedText}</span>
+          <span class="mdc-select__selected-text-container" part="selected-text-container">
+            <span class="mdc-select__selected-text" part="selected-text">${this.selectedText}</span>
           </span>
-          <span class="mdc-select__dropdown-icon">
+          <span class="mdc-select__dropdown-icon" part="dropdown-icon">
             <svg
                 class="mdc-select__dropdown-icon-graphic"
+                part="dropdown-icon-graphic"
                 viewBox="7 10 10 5"
                 focusable="false">
               <polygon
                   class="mdc-select__dropdown-icon-inactive"
+                  part="dropdown-icon-inactive"
                   stroke="none"
                   fill-rule="evenodd"
                   points="7 10 12 15 17 10">
               </polygon>
               <polygon
                   class="mdc-select__dropdown-icon-active"
+                  part="dropdown-icon-active"
                   stroke="none"
                   fill-rule="evenodd"
                   points="7 15 12 10 17 15">
@@ -339,7 +345,7 @@ export abstract class SelectBase extends FormElement {
     }
 
     return html`
-      <span class="mdc-select__ripple"></span>
+      <span class="mdc-select__ripple" part="ripple"></span>
     `;
   }
 
@@ -366,7 +372,7 @@ export abstract class SelectBase extends FormElement {
       <span
           .floatingLabelFoundation=${
         floatingLabel(this.label) as unknown as MDCFloatingLabelFoundation}
-          id="label">${this.label}</span>
+          id="label" part="label">${this.label}</span>
     `;
   }
 
@@ -386,7 +392,7 @@ export abstract class SelectBase extends FormElement {
 
     return html`
       <span .lineRippleFoundation=${
-        lineRipple() as unknown as MDCLineRippleFoundation}></span>
+        lineRipple() as unknown as MDCLineRippleFoundation} part="line-ripple"></span>
     `;
   }
 
@@ -402,7 +408,7 @@ export abstract class SelectBase extends FormElement {
 
     return html`
         <p
-          class="mdc-select-helper-text ${classMap(classes)}"
+          class="mdc-select-helper-text ${classMap(classes)}" part="helper-text"
           id="helper-text">${
         showValidationMessage ? this.validationMessage : this.helper}</p>`;
   }

--- a/packages/slider/slider-base.ts
+++ b/packages/slider/slider-base.ts
@@ -117,6 +117,7 @@ export class SliderBase extends FormElement {
     return html`
     <div
         class="mdc-slider ${rootClasses}"
+        part="slider"
         @pointerdown=${this.onPointerdown}
         @pointerup=${this.onPointerup}
         @contextmenu=${this.onContextmenu}>
@@ -132,6 +133,7 @@ export class SliderBase extends FormElement {
     return html`
       <input
           class="mdc-slider__input end"
+          part="input"
           type="range"
           step=${this.step}
           min=${this.min}
@@ -156,13 +158,13 @@ export class SliderBase extends FormElement {
 
   protected renderTickMarks() {
     return !this.withTickMarks ? nothing : html`
-      <div class="mdc-slider__tick-marks">
+      <div class="mdc-slider__tick-marks" part="tick-marks">
         ${this.tickMarks.map((tickMark) => {
       const isActive = tickMark === TickMark.ACTIVE;
 
       return html`<div class="${
           isActive ? 'mdc-slider__tick-mark--active' :
-                     'mdc-slider__tick-mark--inactive'}"></div>`;
+                     'mdc-slider__tick-mark--inactive'}" part="tick-mark"></div>`;
     })}
       </div>`;
   }
@@ -204,6 +206,7 @@ export class SliderBase extends FormElement {
     return html`
       <div
           class="mdc-slider__thumb end ${endThumbClasses}"
+          part="thumb"
           style=${endThumbStyles}
           @mouseenter=${this.onEndMouseenter}
           @mouseleave=${this.onEndMouseleave}>
@@ -211,16 +214,17 @@ export class SliderBase extends FormElement {
         ${
         this.renderValueIndicator(
             this.valueToValueIndicatorTransform(this.valueEnd))}
-        <div class="mdc-slider__thumb-knob"></div>
+        <div class="mdc-slider__thumb-knob" part="thumb-knob"></div>
       </div>
     `;
   }
 
   protected renderValueIndicator(text: string|number|null) {
     return this.discrete ? html`
-    <div class="mdc-slider__value-indicator-container" aria-hidden="true">
-      <div class="mdc-slider__value-indicator">
-        <span class="mdc-slider__value-indicator-text">
+    <div class="mdc-slider__value-indicator-container"
+        part="value-indicator-container" aria-hidden="true">
+      <div class="mdc-slider__value-indicator" part="value-indicator">
+        <span class="mdc-slider__value-indicator-text" part="value-indicator-text">
           ${text}
         </span>
       </div>

--- a/packages/slider/slider-range-base.ts
+++ b/packages/slider/slider-range-base.ts
@@ -65,6 +65,7 @@ export class SliderRangeBase extends SliderBase {
     return html`
     <div
         class="mdc-slider mdc-slider--range ${rootClasses}"
+        part="range"
         @pointerdown=${this.onPointerdown}
         @pointerup=${this.onPointerup}
         @contextmenu=${this.onContextmenu}>
@@ -76,6 +77,7 @@ export class SliderRangeBase extends SliderBase {
     return html`
       <input
           class="mdc-slider__input start"
+          part="input-start"
           type="range"
           step=${this.step}
           min=${this.min}
@@ -97,6 +99,7 @@ export class SliderRangeBase extends SliderBase {
     return html`
       <input
           class="mdc-slider__input end"
+          part="input-end"
           type="range"
           step=${this.step}
           min=${this.valueStart}
@@ -139,11 +142,11 @@ export class SliderRangeBase extends SliderBase {
     });
 
     return html`
-      <div class="mdc-slider__track">
-        <div class="mdc-slider__track--inactive"></div>
-        <div class="mdc-slider__track--active">
+      <div class="mdc-slider__track" part="track">
+        <div class="mdc-slider__track--inactive" part="track-inactive"></div>
+        <div class="mdc-slider__track--active" part="track-active">
           <div
-              class="mdc-slider__track--active_fill"
+              class="mdc-slider__track--active_fill" part="track-active-fill"
               style=${trackStyles}>
           </div>
         </div>
@@ -182,7 +185,7 @@ export class SliderRangeBase extends SliderBase {
         html`<mwc-ripple class="ripple" unbounded></mwc-ripple>`;
     return html`
       <div
-          class="mdc-slider__thumb start ${startThumbClasses}"
+          class="mdc-slider__thumb start ${startThumbClasses}" part="thumb"
           style=${startThumbStyles}
           @mouseenter=${this.onStartMouseenter}
           @mouseleave=${this.onStartMouseleave}>
@@ -190,7 +193,7 @@ export class SliderRangeBase extends SliderBase {
         ${
         this.renderValueIndicator(
             this.valueToValueIndicatorTransform(this.valueStart))}
-        <div class="mdc-slider__thumb-knob"></div>
+        <div class="mdc-slider__thumb-knob" part="thumb-knob"></div>
       </div>
     `;
   }

--- a/packages/slider/slider-single-base.ts
+++ b/packages/slider/slider-single-base.ts
@@ -45,11 +45,11 @@ export class SliderSingleBase extends SliderBase {
     });
 
     return html`
-      <div class="mdc-slider__track">
-        <div class="mdc-slider__track--inactive"></div>
-        <div class="mdc-slider__track--active">
+      <div class="mdc-slider__track" part="track">
+        <div class="mdc-slider__track--inactive" part="track-inactive"></div>
+        <div class="mdc-slider__track--active" part="track-active">
           <div
-              class="mdc-slider__track--active_fill"
+              class="mdc-slider__track--active_fill" part="track-active-fill"
               style=${trackStyles}>
           </div>
         </div>

--- a/packages/snackbar/mwc-snackbar-base.ts
+++ b/packages/snackbar/mwc-snackbar-base.ts
@@ -73,11 +73,11 @@ export class SnackbarBase extends BaseElement {
       'mdc-snackbar--leading': this.leading,
     };
     return html`
-      <div class="mdc-snackbar ${classMap(classes)}" @keydown="${
-        this._handleKeydown}">
+      <div class="mdc-snackbar ${classMap(classes)}" part="snackbar"
+        @keydown="${this._handleKeydown}">
         <div class="mdc-snackbar__surface">
           ${accessibleSnackbarLabel(this.labelText, this.open)}
-          <div class="mdc-snackbar__actions">
+          <div class="mdc-snackbar__actions" part="actions">
             <slot name="action" @click="${this._handleActionClick}"></slot>
             <slot name="dismiss" @click="${this._handleDismissClick}"></slot>
           </div>

--- a/packages/switch/mwc-switch-base.ts
+++ b/packages/switch/mwc-switch-base.ts
@@ -78,6 +78,7 @@ export class SwitchBase extends FormElement implements MDCSwitchState {
       <button
         type="button"
         class="mdc-switch ${classMap(this.getRenderClasses())}"
+        part="switch"
         role="switch"
         aria-checked="${this.selected}"
         aria-label="${ifDefined(this.ariaLabel || undefined)}"
@@ -91,8 +92,8 @@ export class SwitchBase extends FormElement implements MDCSwitchState {
         @pointerenter="${this.handlePointerEnter}"
         @pointerleave="${this.handlePointerLeave}"
       >
-        <div class="mdc-switch__track"></div>
-        <div class="mdc-switch__handle-track">
+        <div class="mdc-switch__track" part="track"></div>
+        <div class="mdc-switch__handle-track" part="handle-track">
           ${this.renderHandle()}
         </div>
       </button>
@@ -100,6 +101,7 @@ export class SwitchBase extends FormElement implements MDCSwitchState {
       <input
         type="checkbox"
         aria-hidden="true"
+        part="input"
         name="${this.name}"
         .checked=${this.selected}
         .value=${this.value}
@@ -119,10 +121,10 @@ export class SwitchBase extends FormElement implements MDCSwitchState {
   /** @soyTemplate */
   protected renderHandle(): TemplateResult {
     return html`
-      <div class="mdc-switch__handle">
+      <div class="mdc-switch__handle" part="handle">
         ${this.renderShadow()}
         ${this.renderRipple()}
-        <div class="mdc-switch__icons">
+        <div class="mdc-switch__icons" part="icons">
           ${this.renderOnIcon()}
           ${this.renderOffIcon()}
         </div>
@@ -133,8 +135,8 @@ export class SwitchBase extends FormElement implements MDCSwitchState {
   /** @soyTemplate */
   protected renderShadow(): TemplateResult {
     return html`
-      <div class="mdc-switch__shadow">
-        <div class="mdc-elevation-overlay"></div>
+      <div class="mdc-switch__shadow" part="shadow">
+        <div class="mdc-elevation-overlay" part="elevation-overlay"></div>
       </div>
     `;
   }
@@ -143,7 +145,7 @@ export class SwitchBase extends FormElement implements MDCSwitchState {
   protected renderRipple(): TemplateResult {
     if (this.shouldRenderRipple) {
       return html`
-        <div class="mdc-switch__ripple">
+        <div class="mdc-switch__ripple" part="switch-ripple">
           <mwc-ripple
             internalUseStateLayerCustomProperties
             .disabled="${this.disabled}"
@@ -159,7 +161,7 @@ export class SwitchBase extends FormElement implements MDCSwitchState {
   /** @soyTemplate */
   protected renderOnIcon(): TemplateResult {
     return html`
-      <svg class="mdc-switch__icon mdc-switch__icon--on" viewBox="0 0 24 24">
+      <svg class="mdc-switch__icon mdc-switch__icon--on" viewBox="0 0 24 24" part="icon">
         <path d="M19.69,5.23L8.96,15.96l-4.23-4.23L2.96,13.5l6,6L21.46,7L19.69,5.23z" />
       </svg>
     `;
@@ -168,7 +170,7 @@ export class SwitchBase extends FormElement implements MDCSwitchState {
   /** @soyTemplate */
   protected renderOffIcon(): TemplateResult {
     return html`
-      <svg class="mdc-switch__icon mdc-switch__icon--off" viewBox="0 0 24 24">
+      <svg class="mdc-switch__icon mdc-switch__icon--off" viewBox="0 0 24 24" part="icon-off">
         <path d="M20 13H4v-2h16v2z" />
       </svg>
     `;

--- a/packages/tab-bar/mwc-tab-bar-base.ts
+++ b/packages/tab-bar/mwc-tab-bar-base.ts
@@ -63,7 +63,7 @@ export class TabBarBase extends BaseElement {
   // TODO(sorvell): can scroller be optional for perf?
   protected override render() {
     return html`
-      <div class="mdc-tab-bar" role="tablist"
+      <div class="mdc-tab-bar" part="tab-bar" role="tablist"
           @MDCTab:interacted="${this._handleTabInteraction}"
           @keydown="${this._handleKeydown}">
         <mwc-tab-scroller><slot></slot></mwc-tab-scroller>

--- a/packages/tab-indicator/mwc-tab-indicator-base.ts
+++ b/packages/tab-indicator/mwc-tab-indicator-base.ts
@@ -41,9 +41,9 @@ export class TabIndicatorBase extends BaseElement {
     return html`
       <span class="mdc-tab-indicator ${classMap({
       'mdc-tab-indicator--fade': this.fade
-    })}">
-        <span class="mdc-tab-indicator__content ${classMap(contentClasses)}">${
-        this.icon}</span>
+    })}" part="tab-indicator">
+        <span class="mdc-tab-indicator__content ${classMap(contentClasses)}"
+            part="content">${this.icon}</span>
       </span>
       `;
   }

--- a/packages/tab-scroller/mwc-tab-scroller-base.ts
+++ b/packages/tab-scroller/mwc-tab-scroller-base.ts
@@ -40,15 +40,16 @@ export class TabScrollerBase extends BaseElement {
 
   protected override render() {
     return html`
-      <div class="mdc-tab-scroller">
-        <div class="mdc-tab-scroller__scroll-area"
+      <div class="mdc-tab-scroller" part="tab-scroller">
+        <div class="mdc-tab-scroller__scroll-area" part="scroll-area"
             @wheel="${this._handleInteraction}"
             @touchstart="${this._handleInteraction}"
             @pointerdown="${this._handleInteraction}"
             @mousedown="${this._handleInteraction}"
             @keydown="${this._handleInteraction}"
             @transitionend="${this._handleTransitionEnd}">
-          <div class="mdc-tab-scroller__scroll-content"><slot></slot></div>
+          <div class="mdc-tab-scroller__scroll-content"
+              part="scroll-content"><slot></slot></div>
         </div>
       </div>
       `;

--- a/packages/tab/mwc-tab-base.ts
+++ b/packages/tab/mwc-tab-base.ts
@@ -112,20 +112,21 @@ export class TabBase extends BaseElement {
       // NOTE: MUST be on same line as spaces will cause vert alignment issues
       // in IE
       iconTemplate = html`
-        <span class="mdc-tab__icon material-icons"><slot name="icon">${
+        <span class="mdc-tab__icon material-icons" part="material-icons"><slot name="icon">${
           this.icon}</slot></span>`;
     }
 
     let labelTemplate = html``;
     if (this.label) {
       labelTemplate = html`
-        <span class="mdc-tab__text-label">${this.label}</span>`;
+        <span class="mdc-tab__text-label" part="text-label">${this.label}</span>`;
     }
 
     return html`
       <button
         @click="${this.handleClick}"
         class="mdc-tab ${classMap(classes)}"
+        part="tab"
         role="tab"
         aria-selected="false"
         tabindex="-1"
@@ -137,7 +138,7 @@ export class TabBase extends BaseElement {
         @touchstart="${this.handleRippleTouchStart}"
         @touchend="${this.handleRippleDeactivate}"
         @touchcancel="${this.handleRippleDeactivate}">
-        <span class="mdc-tab__content">
+        <span class="mdc-tab__content" part="content">
           ${iconTemplate}
           ${labelTemplate}
           ${this.isMinWidthIndicator ? this.renderIndicator() : ''}

--- a/packages/textarea/mwc-textarea-base.ts
+++ b/packages/textarea/mwc-textarea-base.ts
@@ -69,7 +69,7 @@ export abstract class TextAreaBase extends TextFieldBase {
 
     return html`
       <label class="mdc-text-field mdc-text-field--textarea ${
-        classMap(classes)}">
+        classMap(classes)}" part="textarea">
         ${this.renderRipple()}
         ${this.outlined ? this.renderOutline() : this.renderLabel()}
         ${this.renderInput()}
@@ -97,6 +97,7 @@ export abstract class TextAreaBase extends TextFieldBase {
       <textarea
           aria-labelledby=${ifDefined(ariaLabelledbyOrUndef)}
           class="mdc-text-field__input"
+          part="input"
           .value="${live(this.value) as unknown as string}"
           rows="${this.rows}"
           cols="${this.cols}"

--- a/packages/textfield/mwc-textfield-base.ts
+++ b/packages/textfield/mwc-textfield-base.ts
@@ -288,7 +288,7 @@ export abstract class TextFieldBase extends FormElement {
     };
 
     return html`
-      <label class="mdc-text-field ${classMap(classes)}">
+      <label class="mdc-text-field ${classMap(classes)}" part="text-field">
         ${this.renderRipple()}
         ${this.outlined ? this.renderOutline() : this.renderLabel()}
         ${this.renderLeadingIcon()}
@@ -316,7 +316,7 @@ export abstract class TextFieldBase extends FormElement {
   /** @soyTemplate */
   protected renderRipple(): TemplateResult|string {
     return this.outlined ? '' : html`
-      <span class="mdc-text-field__ripple"></span>
+      <span class="mdc-text-field__ripple" part="ripple"></span>
     `;
   }
 
@@ -339,7 +339,7 @@ export abstract class TextFieldBase extends FormElement {
       <span
           .floatingLabelFoundation=${
             floatingLabel(this.label) as unknown as MDCFloatingLabelFoundation}
-          id="label">${this.label}</span>
+          id="label" part="label">${this.label}</span>
     `;
   }
 
@@ -363,7 +363,7 @@ export abstract class TextFieldBase extends FormElement {
     };
 
     return html`<i class="material-icons mdc-text-field__icon ${
-        classMap(classes)}">${icon}</i>`;
+        classMap(classes)}" part="icon">${icon}</i>`;
   }
 
   /** @soyTemplate */
@@ -385,7 +385,7 @@ export abstract class TextFieldBase extends FormElement {
       'mdc-text-field__affix--suffix': isSuffix
     };
 
-    return html`<span class="mdc-text-field__affix ${classMap(classes)}">
+    return html`<span class="mdc-text-field__affix ${classMap(classes)}" part="affix">
         ${content}</span>`;
   }
 
@@ -414,6 +414,7 @@ export abstract class TextFieldBase extends FormElement {
           aria-controls="${ifDefined(ariaControlsOrUndef)}"
           aria-describedby="${ifDefined(ariaDescribedbyOrUndef)}"
           class="mdc-text-field__input"
+          part="input"
           type="${this.type}"
           .value="${live(this.value) as unknown as string}"
           ?disabled="${this.disabled}"
@@ -442,7 +443,7 @@ export abstract class TextFieldBase extends FormElement {
         '' :
         html`
       <span .lineRippleFoundation=${
-            lineRipple() as unknown as MDCLineRippleFoundation}></span>
+            lineRipple() as unknown as MDCLineRippleFoundation} part="line-ripple"></span>
     `;
   }
 
@@ -468,6 +469,7 @@ export abstract class TextFieldBase extends FormElement {
         <div id="helper-text"
              aria-hidden="${ifDefined(ariaHiddenOrUndef)}"
              class="mdc-text-field-helper-text ${classMap(classes)}"
+             part="helper-text"
              >${helperText}</div>
         ${this.renderCharCounter(shouldRenderCharCounter)}
       </div>`;
@@ -478,7 +480,7 @@ export abstract class TextFieldBase extends FormElement {
       |string {
     const length = Math.min(this.value.length, this.maxLength);
     return !shouldRenderCharCounter ? '' : html`
-      <span class="mdc-text-field-character-counter"
+      <span class="mdc-text-field-character-counter" part="character-counter"
             >${length} / ${this.maxLength}</span>`;
   }
 

--- a/packages/top-app-bar/mwc-top-app-bar-base-base.ts
+++ b/packages/top-app-bar/mwc-top-app-bar-base-base.ts
@@ -75,26 +75,26 @@ export abstract class TopAppBarBaseBase extends BaseElement {
 
   protected override render() {
     // clang-format off
-    let title = html`<span class="mdc-top-app-bar__title"><slot name="title"></slot></span>`;
+    let title = html`<span class="mdc-top-app-bar__title" part="title"><slot name="title"></slot></span>`;
     if (this.centerTitle) {
-      title = html`<section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-center">${title}</section>`;
+      title = html`<section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-center" part="section-align-center">${title}</section>`;
     }
     // clang-format on
     return html`
-      <header class="mdc-top-app-bar ${classMap(this.barClasses())}">
-      <div class="mdc-top-app-bar__row">
-        <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start" id="navigation">
+      <header class="mdc-top-app-bar ${classMap(this.barClasses())}" part="top-app-bar">
+      <div class="mdc-top-app-bar__row" part="row">
+        <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-start" id="navigation" part="section-align-start">
           <slot name="navigationIcon"
             @click=${this.handleNavigationClick}></slot>
           ${this.centerTitle ? null : title}
         </section>
         ${this.centerTitle ? title : null}
-        <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" id="actions" role="toolbar">
+        <section class="mdc-top-app-bar__section mdc-top-app-bar__section--align-end" id="actions" role="toolbar" part="section-align-end">
           <slot name="actionItems"></slot>
         </section>
       </div>
     </header>
-    <div class="${classMap(this.contentClasses())}">
+    <div class="${classMap(this.contentClasses())}" part="content">
       <slot></slot>
     </div>
     `;


### PR DESCRIPTION
Hi
I do understand that the reason of using Web Components is isolating the components but:

### Problem
We were using this library and facing a main problem: **Customization**
So basically we needed to Fork/Extend this repository and manipulate the `SASS` codes to do our customization.

but even then when we need small change like changing a `padding` property or do some `RTL` stuff, the **Shadow Root** does not allow us to do that and we are limited to overriding `--mdc-` attributes like `--mdc-typography-font-family` and those features are so limitted.

### Solution
So generally when we use Web Components the best practice to customize outside of it's shadow root is through the [::part (MDN)](https://developer.mozilla.org/en-US/docs/Web/CSS/::part) attribute to access inside element itself.

I added the `part` attribute to all of non web component elements that are used in templates which I found useful.

Sincerely, @ainyava