### PR TITLE
chore: remove hardcoded lit/reactive-element version

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -11,7 +11,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@lit/reactive-element": "1.0.0-rc.4",
     "@material/base": "=14.0.0-canary.c14e977ee.0",
     "@material/dom": "=14.0.0-canary.c14e977ee.0",
     "lit": "^2.0.0",


### PR DESCRIPTION
In https://github.com/material-components/material-web/commit/6278ee5df98ca7eae0d694e58b052fdbf4b0519d we aligned on lit^2.0.0 but kept an explicit version of @lit/reactive-element for no apparent good reason. This just cleans it up