### PR TITLE
Add support for aria-expanded to button and icon button

### DIFF
--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -123,6 +123,7 @@ mwc-button {
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
 | `aria-haspopup` | `string` | `undefined` | Indicates the availability and type of an interactive popup element, such as menu or dialog, that can be triggered by the button.
+| `aria-expanded` | `string` | `undefined` | Indicates the expanded or collapsed state of content the button may control, such as a menu.
 | `icon` | `string` | `''` | Icon to display, and `aria-label` value when `label` is not defined.
 | `label` | `string` | `''` | Label to display for the button, and `aria-label`.
 | `raised` | `boolean` | `false` | Creates a contained button that is elevated above the surface.

--- a/packages/button/mwc-button-base.ts
+++ b/packages/button/mwc-button-base.ts
@@ -28,6 +28,11 @@ export class ButtonBase extends LitElement {
   @property({type: String, attribute: 'aria-haspopup'})
   override ariaHasPopup!: AriaHasPopup;
 
+  /** @soyPrefixAttribute */
+  @ariaProperty
+  @property({type: String, attribute: 'aria-expanded'})
+    override ariaExpanded!: 'true' | 'false';
+
   @property({type: Boolean, reflect: true}) raised = false;
 
   @property({type: Boolean, reflect: true}) unelevated = false;
@@ -112,6 +117,7 @@ export class ButtonBase extends LitElement {
           ?disabled="${this.disabled}"
           aria-label="${this.label || this.icon}"
           aria-haspopup="${ifDefined(this.ariaHasPopup)}"
+          aria-expanded="${ifDefined(this.ariaExpanded)}"
           @focus="${this.handleRippleFocus}"
           @blur="${this.handleRippleBlur}"
           @mousedown="${this.handleRippleActivate}"

--- a/packages/icon-button/README.md
+++ b/packages/icon-button/README.md
@@ -93,6 +93,7 @@ For technical details about the Material Icons font, see the
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
 | `aria-haspopup` | `string` | `undefined` | Indicates the availability and type of an interactive popup element, such as menu or dialog, that can be triggered by the button.
+| `aria-expanded` | `string` | `undefined` | Indicates the expanded or collapsed state of content the button may control, such as a menu.
 | `icon` | `string` | `''` | Icon to display, and `aria-label` value when `label` is not defined.
 | `aria-label` | `string` | `''` | Accessible label for the button.
 | `disabled` | `boolean` | `false` | Disabled buttons cannot be interacted with and have no visual interaction effect.

--- a/packages/icon-button/mwc-icon-button-base.ts
+++ b/packages/icon-button/mwc-icon-button-base.ts
@@ -32,6 +32,11 @@ export class IconButtonBase extends LitElement {
   @property({type: String, attribute: 'aria-haspopup'})
   override ariaHasPopup!: AriaHasPopup;
 
+  /** @soyPrefixAttribute */
+  @ariaProperty
+  @property({type: String, attribute: 'aria-expanded'})
+  override ariaExpanded!: 'true' | 'false';
+
   @query('button') buttonElement!: HTMLElement;
 
   @queryAsync('mwc-ripple') ripple!: Promise<Ripple|null>;
@@ -75,6 +80,7 @@ export class IconButtonBase extends LitElement {
         class="mdc-icon-button mdc-icon-button--display-flex"
         aria-label="${this.ariaLabel || this.icon}"
         aria-haspopup="${ifDefined(this.ariaHasPopup)}"
+        aria-expanded="${ifDefined(this.ariaExpanded)}"
         ?disabled="${this.disabled}"
         @focus="${this.handleRippleFocus}"
         @blur="${this.handleRippleBlur}"


### PR DESCRIPTION
Fixes #3245 by adding support for the `aria-expanded` attribute in the same manner as `aria-haspopup`.