### PR TITLE
Add focus method to tab bar

### DIFF
--- a/packages/tab-bar/README.md
+++ b/packages/tab-bar/README.md
@@ -263,6 +263,7 @@ _Note: example is in the state of hovering over the first tab._
 
 | Name     | Description
 | -------- | -------------
+| `focus() => void` | Focuses the currently active tab.
 | `scrollIndexIntoView(index:number) => void` | For long, scrollable `tab-bar`s, scrolls the tab at the given index into view.
 
 ### Events

--- a/packages/tab-bar/mwc-tab-bar-base.ts
+++ b/packages/tab-bar/mwc-tab-bar-base.ts
@@ -173,6 +173,13 @@ export class TabBarBase extends BaseElement {
     return result;
   }
 
+  override focus() {
+    const tab = this._getTab(this.activeIndex);
+    if (tab !== undefined) {
+      tab.focus();
+    }
+  }
+
   scrollIndexIntoView(index: number) {
     this.mdcFoundation.scrollIntoView(index);
   }


### PR DESCRIPTION
Fixes #3396 by adding a simple focus method to focus the currently active tab index.