### PR TITLE
chore(manifest): add keywords to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,13 @@
     "url": "https://github.com/material-components/material-web/issues"
   },
   "homepage": "https://github.com/material-components/material-web#readme",
+  "keywords": [
+    "material design",
+    "web components",
+    "UI toolkit",
+    "material you",
+    "google"
+  ],
   "scripts": {
     "clean": "npm run clean:sass && npm run clean:ts",
     "clean:sass": "find . -name '*.css*' -type f -delete",


### PR DESCRIPTION
adds the `keywords` property to package.json with relevant keywords, where it was previously omitted.

noticed there weren't any keywords in the [npm page](https://www.npmjs.com/package/@material/web#keywords) for the package, figured it'd only take me a minute to add some relevant ones :)