### PR TITLE
fixes: Interface 'InertableHTMLElement' incorrectly extends interface 'HTMLElement'

### DIFF
--- a/packages/drawer/mwc-drawer-base.ts
+++ b/packages/drawer/mwc-drawer-base.ts
@@ -27,7 +27,7 @@ import {property, query} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
 
 interface InertableHTMLElement extends HTMLElement {
-  inert?: boolean;
+  inert: boolean;
 }
 
 const blockingElements =


### PR DESCRIPTION
![Screenshot 2022-10-03 at 13 38 39](https://user-images.githubusercontent.com/9133999/193568200-862ba873-84a3-4269-a4fa-c65268d591f7.png)
