### PR TITLE
feat(button,iconbutton): add support for aria-expanded to buttons

### DIFF
--- a/button/lib/button.ts
+++ b/button/lib/button.ts
@@ -20,7 +20,7 @@ import {ariaProperty} from '../../decorators/aria-property.js';
 import {pointerPress, shouldShowStrongFocus} from '../../focus/strong-focus.js';
 import {ripple} from '../../ripple/directive.js';
 import {MdRipple} from '../../ripple/ripple.js';
-import {ARIAHasPopup} from '../../types/aria.js';
+import {ARIAExpanded, ARIAHasPopup} from '../../types/aria.js';
 
 import {ButtonState} from './state.js';
 
@@ -28,6 +28,10 @@ import {ButtonState} from './state.js';
 export abstract class Button extends LitElement implements ButtonState {
   static override shadowRootOptions:
       ShadowRootInit = {mode: 'open', delegatesFocus: true};
+
+  @property({type: String, attribute: 'data-aria-expanded', noAccessor: true})
+  @ariaProperty
+  override ariaExpanded!: ARIAExpanded;
 
   @property({type: String, attribute: 'data-aria-has-popup', noAccessor: true})
   @ariaProperty
@@ -112,6 +116,7 @@ export abstract class Button extends LitElement implements ButtonState {
           ?disabled="${this.disabled}"
           aria-label="${this.ariaLabel || nothing}"
           aria-haspopup="${this.ariaHasPopup || nothing}"
+          aria-expanded="${this.ariaExpanded || nothing}"
           @pointerdown="${this.handlePointerDown}"
           @focus="${this.handleFocus}"
           @blur="${this.handleBlur}"

--- a/iconbutton/lib/icon-button.ts
+++ b/iconbutton/lib/icon-button.ts
@@ -22,7 +22,7 @@ import {ariaProperty} from '../../decorators/aria-property.js';
 import {pointerPress, shouldShowStrongFocus} from '../../focus/strong-focus.js';
 import {ripple} from '../../ripple/directive.js';
 import {MdRipple} from '../../ripple/ripple.js';
-import {ARIAHasPopup} from '../../types/aria.js';
+import {ARIAExpanded, ARIAHasPopup} from '../../types/aria.js';
 
 // tslint:disable-next-line:enforce-comments-on-exported-symbols
 export class IconButton extends LitElement {
@@ -46,6 +46,10 @@ export class IconButton extends LitElement {
   @property({type: String, attribute: 'data-aria-haspopup'})
   override ariaHasPopup!: ARIAHasPopup;
 
+  @ariaProperty
+  @property({type: String, attribute: 'data-aria-expanded'})
+  override ariaExpanded!: ARIAExpanded;
+
   @query('button') protected buttonElement!: HTMLElement;
 
   @queryAsync('md-ripple') protected ripple!: Promise<MdRipple|null>;
@@ -68,6 +72,7 @@ export class IconButton extends LitElement {
         class="md3-icon-button ${classMap(this.getRenderClasses())}"
         aria-label="${ifDefined(this.ariaLabel)}"
         aria-haspopup="${ifDefined(this.ariaHasPopup)}"
+        aria-expanded="${ifDefined(this.ariaExpanded)}"
         ?disabled="${this.disabled}"
         @focus="${this.handleFocus}"
         @blur="${this.handleBlur}"


### PR DESCRIPTION
Fixes #3245 by adding support for the `aria-expanded` attribute in the same manner as `aria-haspopup`.

Note this is identical to #3398 minus the docs since they don't exist yet.
