### PR TITLE
docs: fix button labels

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -46,8 +46,8 @@ Use the `<component-name>` tag in HTML markup. Refer to the
   <md-checkbox checked></md-checkbox>
 </label>
 
-<md-outlined-button label="Back"></md-outlined-button>
-<md-filled-button label="Next"></md-filled-button>
+<md-outlined-button>Back</md-outlined-button>
+<md-filled-button>Next</md-filled-button>
 ```
 
 ## Building


### PR DESCRIPTION
The current docs provide a label property that does not work, so this doc changes that to text inside the element