### PR TITLE
fix(list-item): infer noninteractive property type

### DIFF
--- a/list/lib/listitem/list-item-only.ts
+++ b/list/lib/listitem/list-item-only.ts
@@ -14,7 +14,7 @@ export class ListItemOnly extends ListItemEl {
   /**
    * Removes the hover and click ripples from the item when true.
    */
-  @property() noninteractive = false;
+  @property({type: Boolean}) noninteractive = false;
 
   override getRenderClasses() {
     return {


### PR DESCRIPTION
The `noninteractive` property decorator needs the `type` option set to `Boolean` or else the attribute is ignored.