### PR TITLE
fix(dialog): prevent dialog from closing when escapeKeyAction is empty

### DIFF
--- a/dialog/lib/dialog.ts
+++ b/dialog/lib/dialog.ts
@@ -457,10 +457,14 @@ export class Dialog extends LitElement {
   private handleDialogDismiss(e: Event) {
     if (e.type === 'cancel') {
       this.currentAction = this.escapeKeyAction;
-      if (this.currentAction === '') {
-        e.preventDefault();
-        return;
-      }
+    }
+    // Prevents the <dialog> element from closing when
+    // `escapeKeyAction` is set to an empty string.
+    // It also early returns and avoids <md-dialog> internal state
+    // changes.
+    if (this.currentAction === '') {
+      e.preventDefault();
+      return;
     }
     this.dialogClosedResolver?.();
     this.dialogClosedResolver = undefined;

--- a/dialog/lib/dialog.ts
+++ b/dialog/lib/dialog.ts
@@ -457,14 +457,14 @@ export class Dialog extends LitElement {
   private handleDialogDismiss(e: Event) {
     if (e.type === 'cancel') {
       this.currentAction = this.escapeKeyAction;
-    }
-    // Prevents the <dialog> element from closing when
-    // `escapeKeyAction` is set to an empty string.
-    // It also early returns and avoids <md-dialog> internal state
-    // changes.
-    if (this.currentAction === '') {
-      e.preventDefault();
-      return;
+      // Prevents the <dialog> element from closing when
+      // `escapeKeyAction` is set to an empty string.
+      // It also early returns and avoids <md-dialog> internal state
+      // changes.
+      if (this.escapeKeyAction === '') {
+        e.preventDefault();
+        return;
+      }
     }
     this.dialogClosedResolver?.();
     this.dialogClosedResolver = undefined;

--- a/dialog/lib/dialog.ts
+++ b/dialog/lib/dialog.ts
@@ -457,10 +457,10 @@ export class Dialog extends LitElement {
   private handleDialogDismiss(e: Event) {
     if (e.type === 'cancel') {
       this.currentAction = this.escapeKeyAction;
-	  if (this.currentAction === '') {
-		e.preventDefault();
-		return;
-	  }
+      if (this.currentAction === '') {
+        e.preventDefault();
+        return;
+      }
     }
     this.dialogClosedResolver?.();
     this.dialogClosedResolver = undefined;

--- a/dialog/lib/dialog.ts
+++ b/dialog/lib/dialog.ts
@@ -457,6 +457,10 @@ export class Dialog extends LitElement {
   private handleDialogDismiss(e: Event) {
     if (e.type === 'cancel') {
       this.currentAction = this.escapeKeyAction;
+	  if (this.currentAction === '') {
+		e.preventDefault();
+		return;
+	  }
     }
     this.dialogClosedResolver?.();
     this.dialogClosedResolver = undefined;


### PR DESCRIPTION
This change fixes https://github.com/material-components/material-web/issues/4244

 `escapeKeyAction` set to an empty value should prevent the dialog from closing when user presses the escape key on their keyboard.