### PR TITLE
chore(dialog): provide transition values type

### DIFF
--- a/dialog/demo/demo.ts
+++ b/dialog/demo/demo.ts
@@ -15,9 +15,9 @@ import { DialogTransition } from '../dialog.js';
 
 const collection =
     new MaterialCollection<KnobTypesToKnobs<StoryKnobs>>('Dialog', [
-      new Knob<Extract<DialogTransition, string>, "transition">('transition', {
-        defaultValue: 'grow-down',
-        ui: selectDropdown({
+      new Knob('transition', {
+        defaultValue: 'grow-down' as DialogTransition,
+        ui: selectDropdown<DialogTransition>({
           options: [
             {label: 'grow-down', value: 'grow-down'},
             {label: 'grow-up', value: 'grow-up'},

--- a/dialog/demo/demo.ts
+++ b/dialog/demo/demo.ts
@@ -11,10 +11,11 @@ import {KnobTypesToKnobs, MaterialCollection, materialInitsToStoryInits, setUpDe
 import {boolInput, Knob, selectDropdown, textInput} from './index.js';
 
 import {stories, StoryKnobs} from './stories.js';
+import { DialogTransition } from '../dialog.js';
 
 const collection =
     new MaterialCollection<KnobTypesToKnobs<StoryKnobs>>('Dialog', [
-      new Knob('transition', {
+      new Knob<Extract<DialogTransition, string>, "transition">('transition', {
         defaultValue: 'grow-down',
         ui: selectDropdown({
           options: [

--- a/dialog/demo/stories.ts
+++ b/dialog/demo/stories.ts
@@ -14,12 +14,12 @@ import '@material/web/button/text-button.js';
 import '@material/web/dialog/dialog.js';
 
 import {MaterialStoryInit} from './material-collection.js';
-import {MdDialog} from '@material/web/dialog/dialog.js';
+import {MdDialog, DialogTransition} from '@material/web/dialog/dialog.js';
 import {css, html} from 'lit';
 
 /** Knob types for dialog stories. */
 export interface StoryKnobs {
-  transition: string|undefined;
+  transition?: DialogTransition;
   fullscreen: boolean;
   modeless: boolean;
   footerHidden: boolean;

--- a/dialog/demo/stories.ts
+++ b/dialog/demo/stories.ts
@@ -19,7 +19,7 @@ import {css, html} from 'lit';
 
 /** Knob types for dialog stories. */
 export interface StoryKnobs {
-  transition?: DialogTransition;
+  transition: DialogTransition|undefined;
   fullscreen: boolean;
   modeless: boolean;
   footerHidden: boolean;

--- a/dialog/demo/stories.ts
+++ b/dialog/demo/stories.ts
@@ -112,7 +112,7 @@ const confirm: MaterialStoryInit<StoryKnobs> = {
   }) {
     return html`
       <md-filled-button @click=${clickHandler}>Open</md-filled-button>
-      <md-dialog transition="condense" style="--md-dialog-container-max-inline-size: 320px;"
+      <md-dialog transition="shrink" style="--md-dialog-container-max-inline-size: 320px;"
           .fullscreen=${fullscreen}
           .modeless=${modeless}
           .footerHidden=${footerHidden}

--- a/dialog/dialog.ts
+++ b/dialog/dialog.ts
@@ -9,6 +9,8 @@ import {customElement} from 'lit/decorators.js';
 import {Dialog} from './lib/dialog.js';
 import {styles} from './lib/dialog-styles.css.js';
 
+export {DialogTransition} from './lib/dialog';
+
 declare global {
   interface HTMLElementTagNameMap {
     'md-dialog': MdDialog;

--- a/dialog/lib/dialog.ts
+++ b/dialog/lib/dialog.ts
@@ -26,7 +26,7 @@ const CLOSING_TRANSITION_PROP = '--_closing-transition-duration';
 /**
  * Dialog transition type.
  */
-export type DialogTransition = 'grow'|'shrink'|'grow-down'|'grow-up'|'grow-left'|'grow-right';
+export type DialogTransition = 'grow'|'shrink'|'grow-down'|'grow-up'|'grow-left'|'grow-right'|'';
 
 /**
  * A dialog component.

--- a/dialog/lib/dialog.ts
+++ b/dialog/lib/dialog.ts
@@ -23,6 +23,9 @@ export const CLOSE_ACTION = 'close';
 const OPENING_TRANSITION_PROP = '--_opening-transition-duration';
 const CLOSING_TRANSITION_PROP = '--_closing-transition-duration';
 
+/**
+ * Dialog transition type.
+ */
 export type DialogTransition = 'grow'|'shrink'|'grow-down'|'grow-up'|'grow-left'|'grow-right';
 
 /**

--- a/dialog/lib/dialog.ts
+++ b/dialog/lib/dialog.ts
@@ -203,7 +203,8 @@ export class Dialog extends LitElement {
    *
    * Defaults to grow-down.
    */
-  @property({reflect: true}) transition = 'grow-down';
+  @property({reflect: true})
+  transition: 'grow'|'shrink'|'grow-down'|'grow-up'|'grow-left'|'grow-right' = 'grow-down';
 
   private currentAction: string|undefined;
 

--- a/dialog/lib/dialog.ts
+++ b/dialog/lib/dialog.ts
@@ -23,6 +23,8 @@ export const CLOSE_ACTION = 'close';
 const OPENING_TRANSITION_PROP = '--_opening-transition-duration';
 const CLOSING_TRANSITION_PROP = '--_closing-transition-duration';
 
+export type DialogTransition = 'grow'|'shrink'|'grow-down'|'grow-up'|'grow-left'|'grow-right';
+
 /**
  * A dialog component.
  */
@@ -203,8 +205,7 @@ export class Dialog extends LitElement {
    *
    * Defaults to grow-down.
    */
-  @property({reflect: true})
-  transition: 'grow'|'shrink'|'grow-down'|'grow-up'|'grow-left'|'grow-right' = 'grow-down';
+  @property({reflect: true}) transition: DialogTransition = 'grow-down';
 
   private currentAction: string|undefined;
 


### PR DESCRIPTION
This PR provides the `transition` values type.

This would help with type checking when using `MdDialog` programmatically and also to forward types in tool authoring, e.g.

```typescript
export interface DialogOptions {
	// ...

	/**
	 * Transition of the dialog.
	 * @type {import('@material/web/dialog/dialog.js').MdDialog['transition']}
	 * @default 'grow-down'
	 */
	transition?: MdDialog['transition'];
}
```