### PR TITLE
feat(list): add multiline headline option

### DIFF
--- a/list/demo/demo.ts
+++ b/list/demo/demo.ts
@@ -43,6 +43,8 @@ const collection =
       new Knob('noninteractive', {ui: boolInput(), defaultValue: false}),
       new Knob('active', {ui: boolInput(), defaultValue: false}),
       new Knob(
+          'multiLineHeadline', {ui: boolInput(), defaultValue: false}),
+      new Knob(
           'multiLineSupportingText', {ui: boolInput(), defaultValue: false}),
       new Knob('headline', {ui: textInput(), defaultValue: 'Headline'}),
       new Knob('supportingText', {ui: textInput(), defaultValue: ''}),

--- a/list/demo/stories.ts
+++ b/list/demo/stories.ts
@@ -21,6 +21,7 @@ export interface StoryKnobs {
   disabled: boolean;
   noninteractive: boolean;
   active: boolean;
+  multiLineHeadline: boolean;
   multiLineSupportingText: boolean;
   headline: string;
   supportingText: string;
@@ -68,6 +69,7 @@ const standard: MaterialStoryInit<StoryKnobs> = {
       disabled,
       noninteractive,
       active,
+      multiLineHeadline,
       multiLineSupportingText,
       headline,
       supportingText,
@@ -85,6 +87,7 @@ const standard: MaterialStoryInit<StoryKnobs> = {
           <md-list-item
               .headline=${headline}
               .supportingText=${supportingText}
+              .multiLineHeadline=${multiLineHeadline}
               .multiLineSupportingText=${multiLineSupportingText}
               .trailingSupportingText=${trailingSupportingText}
               .disabled=${disabled}
@@ -96,6 +99,7 @@ const standard: MaterialStoryInit<StoryKnobs> = {
           <md-list-item
               .headline=${headline}
               .supportingText=${supportingText}
+              .multiLineHeadline=${multiLineHeadline}
               .multiLineSupportingText=${multiLineSupportingText}
               .trailingSupportingText=${trailingSupportingText}
               .disabled=${disabled}
@@ -113,6 +117,7 @@ const standard: MaterialStoryInit<StoryKnobs> = {
           <md-list-item-link
               .headline=${headline}
               .supportingText=${supportingText}
+              .multiLineHeadline=${multiLineHeadline}
               .multiLineSupportingText=${multiLineSupportingText}
               .trailingSupportingText=${trailingSupportingText}
               .disabled=${disabled}
@@ -130,6 +135,7 @@ const standard: MaterialStoryInit<StoryKnobs> = {
           <md-list-item
               .headline=${headline}
               .supportingText=${supportingText}
+              .multiLineHeadline=${multiLineHeadline}
               .multiLineSupportingText=${multiLineSupportingText}
               .trailingSupportingText=${trailingSupportingText}
               .disabled=${disabled}
@@ -142,6 +148,7 @@ const standard: MaterialStoryInit<StoryKnobs> = {
           <md-list-item
               .headline=${headline}
               .supportingText=${supportingText}
+              .multiLineHeadline=${multiLineHeadline}
               .multiLineSupportingText=${multiLineSupportingText}
               .trailingSupportingText=${trailingSupportingText}
               .disabled=${disabled}
@@ -156,6 +163,7 @@ const standard: MaterialStoryInit<StoryKnobs> = {
           <md-list-item
               .headline=${headline}
               .supportingText=${supportingText}
+              .multiLineHeadline=${multiLineHeadline}
               .multiLineSupportingText=${multiLineSupportingText}
               .trailingSupportingText=${trailingSupportingText}
               .disabled=${disabled}
@@ -168,6 +176,7 @@ const standard: MaterialStoryInit<StoryKnobs> = {
           <md-list-item
               .headline=${headline}
               .supportingText=${supportingText}
+              .multiLineHeadline=${multiLineHeadline}
               .multiLineSupportingText=${multiLineSupportingText}
               .trailingSupportingText=${trailingSupportingText}
               .disabled=${disabled}

--- a/list/lib/listitem/_list-item.scss
+++ b/list/lib/listitem/_list-item.scss
@@ -181,6 +181,12 @@
     }
   }
 
+  .label-text--multi-line {
+    text-overflow: unset;
+    overflow-x: unset;
+    white-space: normal;
+  }
+
   .supporting-text {
     text-overflow: ellipsis;
     white-space: normal;

--- a/list/lib/listitem/list-item.ts
+++ b/list/lib/listitem/list-item.ts
@@ -42,6 +42,11 @@ export class ListItemEl extends LitElement implements ListItem {
   @property() headline = '';
 
   /**
+   * Modifies `headline` to support multiple lines.
+   */
+  @property({type: Boolean}) multiLineHeadline = false;
+
+  /**
    * The one-line supporting text below the headline. Set
    * `multiLineSupportingText` to `true` to support multiple lines in the
    * supporting text.
@@ -191,7 +196,14 @@ export class ListItemEl extends LitElement implements ListItem {
         this.supportingText !== '' ? this.renderSupportingText() : '';
 
     return html`<div class="body"
-      ><span class="label-text">${this.headline}</span>${supportingText}</div>`;
+      ><span class="label-text ${classMap(this.getLabelClasses())}">${this.headline}</span>${supportingText}</div>`;
+  }
+
+  /**
+   * Gets the classes for the label node
+   */
+  protected getLabelClasses() {
+    return {'label-text--multi-line': this.multiLineHeadline};
   }
 
   /**


### PR DESCRIPTION
A recent release of `@material/web` removed the ability for the headline / label text of an `md-list-item` to wrap if it was too long, this pull request adds an option to opt back in to the previous wrapping behavior.

Obviously, feel free to change whatever makes sense, I just wanted to request the ability to have a wrapping headline for lists where the list items are not known ahead of time (and maybe longer than I'd like the width of the list to be). I wanted to contribute in whatever way I could to make delivery quicker. :)