### PR TITLE
build(catalog): re-enable catalog typechecking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ catalog/site/components/images
 catalog/*.tsbuildinfo
 catalog/stories/*/
 !catalog/stories/components/
+!catalog/src/types/**/*.d.ts

--- a/catalog/package.json
+++ b/catalog/package.json
@@ -22,7 +22,8 @@
     "build:dev": {
       "dependencies": [
         "build:dev:eleventy",
-        "build:dev:ts"
+        "build:dev:ts",
+        "build:type-check"
       ]
     },
     "build:dev:eleventy": {
@@ -66,12 +67,16 @@
       "clean": "if-file-deleted",
       "output": [
         "tsconfig.tsbuildinfo"
+      ],
+      "dependencies": [
+        "..:build"
       ]
     },
     "build:prod": {
       "dependencies": [
         "build:prod:eleventy",
-        "build:prod:ts"
+        "build:prod:ts",
+        "build:type-check"
       ]
     },
     "build:prod:eleventy": {

--- a/catalog/src/types/is-land.d.ts
+++ b/catalog/src/types/is-land.d.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+declare module '@11ty/is-land' {
+  export class Island extends HTMLElement {
+    forceFallback(): void;
+  }
+}

--- a/catalog/tsconfig.json
+++ b/catalog/tsconfig.json
@@ -12,7 +12,8 @@
     "useDefineForClassFields": false,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": []
   },
   "include": ["src/**/*", "stories/*", "stories/components"],
   "exclude": []


### PR DESCRIPTION
This enables typechecking on the catalog so that we catch type build issues in CI next time. Type issues didn't break before since we run our code through esbuild, and it was disabled because of some weird 11ty issues that are fixed in this CL

This should prevent issues like b/288481318 from passing by again

Depends on #4489 to merge first