### PR TITLE
chore(dialog): transition improvements code

### DIFF
--- a/dialog/lib/_dialog.scss
+++ b/dialog/lib/_dialog.scss
@@ -194,7 +194,9 @@
   // Transitions for open/closed states
   .container {
     will-change: transform, opacity;
+    // TODO: make opacity fade out content and container separately
     transition-property: transform, opacity;
+    transition-timing-function: var(--_closing-transition-easing), linear;
     overflow: hidden;
   }
 

--- a/dialog/lib/_dialog.scss
+++ b/dialog/lib/_dialog.scss
@@ -110,6 +110,8 @@
     max-inline-size: var(--_container-max-inline-size);
     padding-block-start: var(--_container-block-padding);
     padding-block-end: var(--_container-block-padding);
+
+    opacity: 0;
   }
 
   md-elevation {
@@ -192,7 +194,7 @@
   // Transitions for open/closed states
   .container {
     will-change: transform, opacity;
-    transition-property: transform;
+    transition-property: transform, opacity;
     overflow: hidden;
   }
 

--- a/dialog/lib/_dialog.scss
+++ b/dialog/lib/_dialog.scss
@@ -241,7 +241,7 @@
     transition-timing-function: var(--_closing-transition-easing);
   }
 
-  :host([trasition][closing]) .container > * {
+  :host([transition][closing]) .container > * {
     transform: none;
     opacity: 0;
   }

--- a/dialog/lib/dialog.ts
+++ b/dialog/lib/dialog.ts
@@ -393,7 +393,8 @@ export class Dialog extends LitElement {
     let promise = this.updateComplete;
     if (duration > 0) {
       promise = new Promise((r) => {
-        setTimeout(r, duration);
+        // setTimeout(r, duration);
+        this.containerElement.ontransitionend = () => r(null);
       });
     }
     await promise;

--- a/dialog/lib/dialog.ts
+++ b/dialog/lib/dialog.ts
@@ -347,12 +347,14 @@ export class Dialog extends LitElement {
         this.dialogElement!.showModal();
       }
     }
-    // Avoids dispatching initial state.
-    const shouldDispatchAction = changed.get('open') !== undefined;
+    // Avoids dispatching initial closed state
+	 // and performing an unnecessary transition.
+    const shouldTransition =
+      !(changed.get('open') === undefined && this.open === false) &&
+      changed.get('open') !== this.open;
 
-    // Avoids performing unnecessary transition
-    if (changed.get('open') !== undefined && changed.get('open') !== this.open) {
-      this.performTransition(shouldDispatchAction);
+    if (shouldTransition) {
+      this.performTransition();
     }
   }
 
@@ -380,21 +382,20 @@ export class Dialog extends LitElement {
 
   private dialogClosedResolver?: () => void;
 
-  private async performTransition(shouldDispatchAction: boolean) {
+  private async performTransition(/*shouldDispatchAction: boolean*/) {
     // TODO: pause here only to avoid a double update warning.
     await this.updateComplete;
     this.showingOpen = this.open;
-    if (shouldDispatchAction) {
+   //  if (shouldDispatchAction) {
       this.dispatchActionEvent(this.open ? 'opening' : 'closing');
-    }
+   //  }
     // Compute desired transition duration.
     const duration = msFromTimeCSSValue(getComputedStyle(this).getPropertyValue(
         this.open ? OPENING_TRANSITION_PROP : CLOSING_TRANSITION_PROP));
     let promise = this.updateComplete;
     if (duration > 0) {
       promise = new Promise((r) => {
-        // setTimeout(r, duration);
-        this.containerElement.ontransitionend = () => r(null);
+        setTimeout(r, duration);
       });
     }
     await promise;
@@ -424,9 +425,9 @@ export class Dialog extends LitElement {
     if (this.open) {
       this.focus();
     }
-    if (shouldDispatchAction) {
+   //  if (shouldDispatchAction) {
       this.dispatchActionEvent(this.open ? 'opened' : 'closed');
-    }
+   //  }
     this.currentAction = undefined;
   }
 

--- a/dialog/lib/dialog.ts
+++ b/dialog/lib/dialog.ts
@@ -348,7 +348,7 @@ export class Dialog extends LitElement {
       }
     }
     // Avoids dispatching initial closed state
-	 // and performing an unnecessary transition.
+    // and performing an unnecessary transition.
     const shouldTransition =
       !(changed.get('open') === undefined && this.open === false) &&
       changed.get('open') !== this.open;

--- a/dialog/lib/dialog.ts
+++ b/dialog/lib/dialog.ts
@@ -349,7 +349,11 @@ export class Dialog extends LitElement {
     }
     // Avoids dispatching initial state.
     const shouldDispatchAction = changed.get('open') !== undefined;
-    this.performTransition(shouldDispatchAction);
+
+    // Avoids performing unnecessary transition
+    if (changed.get('open') !== undefined && changed.get('open') !== this.open) {
+      this.performTransition(shouldDispatchAction);
+    }
   }
 
   /**


### PR DESCRIPTION
Few improvements:

- fix a typo in `_dialog.scss` (`trasition` => `transition`)
- condition `performTransition` to only perform a transition when `this.open` new and old values are different.
- set opacity to 0 on `containerElement` when it's closed and 1 when it opens, so opening and closing animation feels smoother.