### PR TITLE
fix(repo): remove "." from workspace config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0-pre.11",
       "license": "Apache-2.0",
       "workspaces": [
-        ".",
         "catalog"
       ],
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "!catalog"
   ],
   "workspaces": [
-    ".",
     "catalog"
   ],
   "dependencies": {


### PR DESCRIPTION
The `"."` in workspaces config seems to create an infinite recursive symlink as seen here https://github.com/google/wireit/issues/790

It looks unnecessary to include the root directory in the workspaces config. No commands in the repo currently use the `--workspace` or `--workspaces` flag for npm commands so those commands should not be affected.

If there were `--workspaces` flags meant to run a command for all workspace directories, the root directory can be included by `--include-workspace-root` flag as well. https://docs.npmjs.com/cli/v8/commands/npm-run-script#include-workspace-root

`@material/web` use within the `catalog` workspace still correctly resolves to the root package with the reference, and does not install its own copy from npm.