### PR TITLE
chore(chip): reflect filter chip selected value

### DIFF
--- a/chips/lib/filter-chip.ts
+++ b/chips/lib/filter-chip.ts
@@ -20,7 +20,7 @@ import {renderRemoveButton} from './trailing-icons.js';
 export class FilterChip extends MultiActionChip {
   @property({type: Boolean}) elevated = false;
   @property({type: Boolean}) removable = false;
-  @property({type: Boolean}) selected = false;
+  @property({type: Boolean, reflect: true}) selected = false;
 
   protected get primaryId() {
     return 'option';

--- a/chips/lib/input-chip.ts
+++ b/chips/lib/input-chip.ts
@@ -20,7 +20,7 @@ export class InputChip extends MultiActionChip {
   @property() href = '';
   @property() target: '_blank'|'_parent'|'_self'|'_top'|'' = '';
   @property({type: Boolean, attribute: 'remove-only'}) removeOnly = false;
-  @property({type: Boolean, refect: true}) selected = false;
+  @property({type: Boolean, reflect: true}) selected = false;
 
   protected get primaryId() {
     if (this.href) {

--- a/chips/lib/input-chip.ts
+++ b/chips/lib/input-chip.ts
@@ -20,7 +20,7 @@ export class InputChip extends MultiActionChip {
   @property() href = '';
   @property() target: '_blank'|'_parent'|'_self'|'_top'|'' = '';
   @property({type: Boolean, attribute: 'remove-only'}) removeOnly = false;
-  @property({type: Boolean}) selected = false;
+  @property({type: Boolean, refect: true}) selected = false;
 
   protected get primaryId() {
     if (this.href) {


### PR DESCRIPTION
In a chip set context, there are currently no way to query selected chips from the outside  
(e.g. `queryAll('md-filter-chip[selected]')`).

This PR solves that problem.