### PR TITLE
fix: wireit sass watch memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,9 +98,10 @@
       ]
     },
     "build:sass": {
-      "command": "sass --style=compressed --load-path=node_modules --load-path=node_modules/sass-true/sass $(ls -d */ | grep -v node_modules)",
+      "command": "sass --style=compressed --load-path=node_modules --load-path=node_modules/sass-true/sass $(ls -d */ | grep -v node_modules | grep -v catalog)",
       "files": [
-        "**/*.scss"
+        "**/*.scss",
+        "!catalog"
       ],
       "output": [
         "**/*.css",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
       ]
     },
     "build:sass": {
-      "command": "sass --style=compressed --load-path=node_modules --load-path=node_modules/sass-true/sass $(ls -d */ | grep -v node_modules | grep -v catalog)",
+      "command": "sass --style=compressed --load-path=node_modules --load-path=node_modules/sass-true/sass $(ls -d */ | grep -vE 'node_modules|catalog')",
       "files": [
         "**/*.scss",
         "!catalog"


### PR DESCRIPTION
This will avoid wireit looping through the `@material/web` symbolic link in watch mode.