### PR TITLE
fix: catalog dev watch memory leak

### DIFF
--- a/catalog/package.json
+++ b/catalog/package.json
@@ -146,7 +146,8 @@
       "command": "node scripts/copy-stories.mjs",
       "files": [
         "scripts/copy-stories.mjs",
-        "../*/demo"
+        "../*/demo",
+        "!../node_modules"
       ],
       "output": [
         "stories/*/**/*",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "!catalog"
   ],
   "workspaces": [
+    ".",
     "catalog"
   ],
   "dependencies": {


### PR DESCRIPTION
Following https://github.com/material-components/material-web/pull/4506 which didn't really solve the memory leak, just slowed it down.

This PR really solves the memory leak problem which originated from the `copy-stories` wireit task in the `catalog` package.  
`../*/demo` value in `files` field was expanding to `../node_modules/...` paths, causing the loop.