### PR TITLE
fix(radio): prevent triggering click action on radio keyboard navigation

### DIFF
--- a/radio/lib/single-selection-controller.ts
+++ b/radio/lib/single-selection-controller.ts
@@ -216,8 +216,13 @@ export class SingleSelectionController implements ReactiveController {
       }
 
       // The next sibling should be checked, focused and dispatch a change event
+      nextSibling.checked = true;
       nextSibling.removeAttribute('tabindex');
-      nextSibling.click();
+      nextSibling.focus();
+      // Fire a change event since the change is triggered by a user action.
+      // This matches native <input type="radio"> behavior.
+      nextSibling.dispatchEvent(new Event('change', {bubbles: true}));
+
       break;
     }
   };


### PR DESCRIPTION
As click events propagates, triggering a click action on radio-button creates potential unwanted side-effect (for instance, it will activate ripple effect of parent container like `md-list-item`).

Here, I propose to revert #4518 to its original form - without 3436d023a0caca9181e65a7a1189f3fda694f840.

See https://github.com/material-components/material-web/pull/4518#issuecomment-1625625170 for justification.