### PR TITLE
fix(segmentedbutton): add back container height token

### DIFF
--- a/tokens/_md-comp-outlined-segmented-button.scss
+++ b/tokens/_md-comp-outlined-segmented-button.scss
@@ -16,6 +16,7 @@
 
 $supported-tokens: (
   // go/keep-sorted start
+  'container-height',
   'disabled-icon-color',
   'disabled-label-text-color',
   'disabled-outline-color',
@@ -51,7 +52,6 @@ $supported-tokens: (
 
 $unsupported-tokens: (
   // go/keep-sorted start
-  'container-height',
   'disabled-icon-opacity',
   'disabled-label-text-opacity',
   'disabled-outline-opacity',


### PR DESCRIPTION
It fixes the height of the container (which is of 40px in the specifications).