### PR TITLE
fix(list): list item body overflow issue

### DIFF
--- a/list/internal/listitem/_list-item.scss
+++ b/list/internal/listitem/_list-item.scss
@@ -134,7 +134,7 @@
     display: inline-flex;
     justify-content: center;
     flex-direction: column;
-    max-width: 100%;
+    min-width: 0;
     box-sizing: border-box;
     flex: 1 0 0;
     padding-inline-start: var(--_list-item-leading-space);

--- a/list/internal/listitem/_list-item.scss
+++ b/list/internal/listitem/_list-item.scss
@@ -134,6 +134,7 @@
     display: inline-flex;
     justify-content: center;
     flex-direction: column;
+    max-width: 100%;
     box-sizing: border-box;
     flex: 1 0 0;
     padding-inline-start: var(--_list-item-leading-space);
@@ -160,7 +161,6 @@
   }
 
   .label-text {
-    display: flex;
     text-overflow: ellipsis;
     overflow-x: hidden;
     white-space: nowrap;


### PR DESCRIPTION
Hey there!

Excited to be contributing to this repository for the first time!

So, in this pull request, I tackled an issue with overflowing content in the list-item's body. The fix was pretty straightforward - I set `max-width: 100%` to the list-item's body element. To make things even better, I also got rid of the `display: flex` from `label-text`, which wasn't doing much except making truncation more complicated. I mean, it's just text inside label-text, so no need for flex, right?

Here's how it looks like:

<img width="378" alt="Screenshot showing the fixed list-item's body content" src="https://github.com/material-components/material-web/assets/23614886/41a93e10-2be8-45a4-a281-e84e7c5802ec">

Many thanks for checking this out! Looking forward to your review!

Cheers,
David