### PR TITLE
fix(list-item): rename selector

### DIFF
--- a/list/internal/listitem/_list-item.scss
+++ b/list/internal/listitem/_list-item.scss
@@ -85,7 +85,7 @@
     }
   }
 
-  .content-wrapper {
+  .container {
     display: flex;
     width: 100%;
     box-sizing: border-box;

--- a/list/internal/listitem/list-item.ts
+++ b/list/internal/listitem/list-item.ts
@@ -131,7 +131,7 @@ export class ListItemEl extends LitElement implements ListItem {
 
   protected override render() {
     return this.renderListItem(html`
-      <div class="content-wrapper">
+      <div class="container">
         ${this.renderStart()}
         ${this.renderBody()}
         ${this.renderEnd()}


### PR DESCRIPTION
I renamed content-wrapper to container since the latter made more sense to me and also matches the naming used in TextField. You may close this PR if you disagree 😅