### PR TITLE
fix(badge): center align value text

### DIFF
--- a/labs/badge/internal/_badge.scss
+++ b/labs/badge/internal/_badge.scss
@@ -62,6 +62,7 @@
 
       .md3-badge__value {
         padding: 0px 4px;
+        text-align: center;
       }
     }
   }


### PR DESCRIPTION
I noticed the text in the badge was not properly centered. This is the first solution that came to my mind, any thought on that?


![image](https://github.com/material-components/material-web/assets/2827383/06a1752e-fc1b-49c5-af58-cb495978e103)
