### PR TITLE
chore: update typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "jasmine": "^4.5.0",
         "sass": "^1.52.3",
         "sass-true": "^6.1.0",
-        "typescript": "^5.1.6",
+        "typescript": "5.1.6",
         "web-test-runner-jasmine": "^0.0.2",
         "wireit": "^0.9.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "catalog"
       ],
       "dependencies": {
-        "lit": "^2.7.4",
-        "safevalues": "^0.4.3",
+        "lit": "^2.7.4 || ^3.0.0",
         "tslib": "^2.4.0"
       },
       "devDependencies": {
@@ -23,7 +22,7 @@
         "jasmine": "^4.5.0",
         "sass": "^1.52.3",
         "sass-true": "^6.1.0",
-        "typescript": "4.9.4",
+        "typescript": "^5.1.6",
         "web-test-runner-jasmine": "^0.0.2",
         "wireit": "^0.9.0"
       }
@@ -5747,6 +5746,19 @@
         "typescript": "^2.9.2 || ^3.0.0 || ^4.0.0"
       }
     },
+    "node_modules/parse-literals/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
@@ -6688,11 +6700,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "node_modules/safevalues": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/safevalues/-/safevalues-0.4.3.tgz",
-      "integrity": "sha512-pNCNTkx3xs7G5YJ/9CoeZZVUSPRjH0SEPM0QI5Z1FZRlLBviTFWlNKPs8PTvZvERV0gO7ie/t/Zc0S96JS4Xew=="
-    },
     "node_modules/sass": {
       "version": "1.63.4",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.4.tgz",
@@ -7194,16 +7201,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typical": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jasmine": "^4.5.0",
     "sass": "^1.52.3",
     "sass-true": "^6.1.0",
-    "typescript": "4.9.4",
+    "typescript": "^5.1.6",
     "web-test-runner-jasmine": "^0.0.2",
     "wireit": "^0.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "jasmine": "^4.5.0",
     "sass": "^1.52.3",
     "sass-true": "^6.1.0",
-    "typescript": "^5.1.6",
+    "typescript": "5.1.6",
     "web-test-runner-jasmine": "^0.0.2",
     "wireit": "^0.9.0"
   },


### PR DESCRIPTION
Updates to internal version so we can use things like `as const`