### PR TITLE
fix(tabs): apply shape to tab elevation

### DIFF
--- a/tabs/internal/_tab.scss
+++ b/tabs/internal/_tab.scss
@@ -72,7 +72,8 @@
   }
 
   .button::before,
-  md-ripple {
+  md-ripple,
+  md-elevation {
     border-start-start-radius: var(--_container-shape-start-start);
     border-start-end-radius: var(--_container-shape-start-end);
     border-end-end-radius: var(--_container-shape-end-end);


### PR DESCRIPTION
The elevation of a tab is displayed in square shape:
![image](https://github.com/material-components/material-web/assets/2802675/de29fc80-5c25-4578-9aba-87c67821de29)

This fix is applying the shape to `md-elevation` element as well:
![image](https://github.com/material-components/material-web/assets/2802675/e0a66c56-0a7d-4730-a142-8670f2200c28)
