### PR TITLE
Corrected button trailing-icon

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -203,7 +203,7 @@ box](images/button/usage-icon.png "Slot in icons to the appropriate slots")
       <svg slot="icon" viewBox="0 0 48 48"><path d="M6 40V8l38 16Zm3-4.65L36.2 24 9 12.5v8.4L21.1 24 9 27Zm0 0V12.5 27Z"/></svg>
     </md-filled-tonal-button>
 
-    <md-text-button trailingicon>
+    <md-text-button trailing-icon>
       Open
       <svg slot="icon" viewBox="0 0 48 48"><path d="M9 42q-1.2 0-2.1-.9Q6 40.2 6 39V9q0-1.2.9-2.1Q7.8 6 9 6h13.95v3H9v30h30V25.05h3V39q0 1.2-.9 2.1-.9.9-2.1.9Zm10.1-10.95L17 28.9 36.9 9H25.95V6H42v16.05h-3v-10.9Z"/></svg>
     </md-text-button>
@@ -220,7 +220,7 @@ box](images/button/usage-icon.png "Slot in icons to the appropriate slots")
   <svg slot="icon" viewBox="0 0 48 48"><path d="M6 40V8l38 16Zm3-4.65L36.2 24 9 12.5v8.4L21.1 24 9 27Zm0 0V12.5 27Z"/></svg>
 </md-filled-tonal-button>
 
-<md-text-button trailingicon>
+<md-text-button trailing-icon>
   Open
   <svg slot="icon" viewBox="0 0 48 48"><path d="M9 42q-1.2 0-2.1-.9Q6 40.2 6 39V9q0-1.2.9-2.1Q7.8 6 9 6h13.95v3H9v30h30V25.05h3V39q0 1.2-.9 2.1-.9.9-2.1.9Zm10.1-10.95L17 28.9 36.9 9H25.95V6H42v16.05h-3v-10.9Z"/></svg>
 </md-text-button>


### PR DESCRIPTION
On https://material-web.dev/components/button/, both the icons are at the front. The correct attribute is `trailing-icon`. Source code:

https://github.com/material-components/material-web/blob/573caaee1b7fe64b57b84e2b287b6c5c74666de1/button/internal/button.ts#L59