### PR TITLE
chore: add GitHub issue templates for bugs & links to docs and community

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -11,26 +11,9 @@ body:
       multiple: true
       description: Note you can select more than one.
       options:
-        - Button
-        - Checkbox
-        - Chips
-        - Dialog
-        - Divider
-        - Elevation
-        - FAB
-        - Field
-        - Focus
-        - Icon Button
-        - List
-        - Menu
-        - Progress indicators
-        - Radio
-        - Ripple
-        - Select
-        - Slider
-        - Switch
-        - Tabs
-        - Textfield
+        - Accessibility
+        - Component
+        - Theming
         - Tooling
         - Other/unknown
 
@@ -57,20 +40,12 @@ body:
       description: |
         If possible, please link to a working reproduction that will help us verify and understand the bug.
         Bugs that provide a reproduction in CodePen, Fiddle, or lit.dev playground ([Example Playground](https://lit.dev/playground/#project=W3sibmFtZSI6Im1hdGVyaWFsLWltcG9ydHMuanMiLCJjb250ZW50IjoiaW1wb3J0IFwiQG1hdGVyaWFsL3dlYi9idXR0b24vb3V0bGluZWQtYnV0dG9uLmpzXCI7In0seyJuYW1lIjoiaW5kZXguaHRtbCIsImNvbnRlbnQiOiI8IURPQ1RZUEUgaHRtbD5cbjxzY3JpcHQgdHlwZT1cIm1vZHVsZVwiIHNyYz1cIi4vbWF0ZXJpYWwtaW1wb3J0cy5qc1wiPjwvc2NyaXB0PlxuXG48bWQtb3V0bGluZWQtYnV0dG9uPkEgbWF0ZXJpYWwgYnV0dG9uPC9tZC1vdXRsaW5lZC1idXR0b24-XG4ifSx7Im5hbWUiOiJwYWNrYWdlLmpzb24iLCJjb250ZW50Ijoie1xuICBcImRlcGVuZGVuY2llc1wiOiB7XG4gICAgXCJsaXRcIjogXCJeMi4wLjBcIixcbiAgICBcIkBsaXQvcmVhY3RpdmUtZWxlbWVudFwiOiBcIl4xLjAuMFwiLFxuICAgIFwibGl0LWVsZW1lbnRcIjogXCJeMy4wLjBcIixcbiAgICBcImxpdC1odG1sXCI6IFwiXjIuMC4wXCJcbiAgfVxufSIsImhpZGRlbiI6dHJ1ZX1d))
-        can be traiged much faster.
+        can be triaged much faster.
 
-        For bugs that show up on the command-line, please create a public GitHub repo, and provide step-by-step instructions for cloning, setting up, and observing the bug.
+        For bugs that show up on the command-line, please create a [Stackblitz](https://stackblitz.com/) Node.js/Vite project, and provide step-by-step instructions for setting up, and observing the bug.
       placeholder: |
         The text should update when the button is clicked, but it doesn't:
-        https://lit.dev/playground/#gist=b90fc1b4d2ee57120763d2e7db934511
-
-        ... or for command-line issues:
-
-        1. git clone git@github.com:<user>/<repo>.git
-        2. cd <repo>
-        3. npm ci
-        4. npm run serve
-        5. Observe the error "Error: Cannot do something"
+        https://lit.dev/playground/#gist=f9817b9c703e037b5ac576030110a983
 
   - type: textarea
     id: workaround

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,123 @@
+name: 🐛 Bug Report
+description: Report a bug that affects a Material Web component
+
+body:
+  - type: dropdown
+    id: affected
+    validations:
+      required: true
+    attributes:
+      label: What is affected?
+      multiple: true
+      description: Note you can select more than one.
+      options:
+        - Button
+        - Checkbox
+        - Chips
+        - Dialog
+        - Divider
+        - Elevation
+        - FAB
+        - Field
+        - Focus
+        - Icon Button
+        - List
+        - Menu
+        - Progress indicators
+        - Radio
+        - Ripple
+        - Select
+        - Slider
+        - Switch
+        - Tabs
+        - Textfield
+        - Tooling
+        - Other/unknown
+
+  - type: textarea
+    id: description
+    validations:
+      required: true
+    attributes:
+      label: Description
+      description: |
+        Please describe the bug in as much detail as possible. Include what you expected to happen, and what actually happened. If you have an error message, please include as much of the error message as possible.
+      placeholder: |
+        When I do '...'.
+        I would expect '...'.
+        However, instead '...' happens.
+
+
+  - type: textarea
+    id: reproduction
+    validations:
+      required: true
+    attributes:
+      label: Reproduction
+      description: |
+        If possible, please link to a working reproduction that will help us verify and understand the bug.
+        Bugs that provide a reproduction in CodePen, Fiddle, or lit.dev playground ([Example Playground](https://lit.dev/playground/#project=W3sibmFtZSI6Im1hdGVyaWFsLWltcG9ydHMuanMiLCJjb250ZW50IjoiaW1wb3J0IFwiQG1hdGVyaWFsL3dlYi9idXR0b24vb3V0bGluZWQtYnV0dG9uLmpzXCI7In0seyJuYW1lIjoiaW5kZXguaHRtbCIsImNvbnRlbnQiOiI8IURPQ1RZUEUgaHRtbD5cbjxzY3JpcHQgdHlwZT1cIm1vZHVsZVwiIHNyYz1cIi4vbWF0ZXJpYWwtaW1wb3J0cy5qc1wiPjwvc2NyaXB0PlxuXG48bWQtb3V0bGluZWQtYnV0dG9uPkEgbWF0ZXJpYWwgYnV0dG9uPC9tZC1vdXRsaW5lZC1idXR0b24-XG4ifSx7Im5hbWUiOiJwYWNrYWdlLmpzb24iLCJjb250ZW50Ijoie1xuICBcImRlcGVuZGVuY2llc1wiOiB7XG4gICAgXCJsaXRcIjogXCJeMi4wLjBcIixcbiAgICBcIkBsaXQvcmVhY3RpdmUtZWxlbWVudFwiOiBcIl4xLjAuMFwiLFxuICAgIFwibGl0LWVsZW1lbnRcIjogXCJeMy4wLjBcIixcbiAgICBcImxpdC1odG1sXCI6IFwiXjIuMC4wXCJcbiAgfVxufSIsImhpZGRlbiI6dHJ1ZX1d))
+        can be traiged much faster.
+
+        For bugs that show up on the command-line, please create a public GitHub repo, and provide step-by-step instructions for cloning, setting up, and observing the bug.
+      placeholder: |
+        The text should update when the button is clicked, but it doesn't:
+        https://lit.dev/playground/#gist=b90fc1b4d2ee57120763d2e7db934511
+
+        ... or for command-line issues:
+
+        1. git clone git@github.com:<user>/<repo>.git
+        2. cd <repo>
+        3. npm ci
+        4. npm run serve
+        5. Observe the error "Error: Cannot do something"
+
+  - type: textarea
+    id: workaround
+    validations:
+      required: true
+    attributes:
+      label: Workaround
+      description: |
+        If you have found a workaround for this problem, please explain it here. If you have not found a workaround, please write "I have not found a workaround".
+      placeholder: |
+        I have worked around this problem by registering the event handler manually with `addEventListener`.
+
+        ... or:
+
+        I have not found a workaround.
+
+  - type: dropdown
+    id: regression
+    validations:
+      required: true
+    attributes:
+      label: Is this a regression?
+      multiple: false
+      options:
+        - Yes. This used to work, but now it doesn't.
+        - No or unsure. This never worked, or I haven't tried before.
+
+  - type: input
+    id: version
+    validations:
+      required: true
+    attributes:
+      label: Affected versions
+      description: Please specify which version of the package you are using, and if this is a known regression, what is the last known version that worked? Run e.g. `npm ls @material/web` to check your installed version.
+      placeholder: |
+        Failing in X.X.X, worked in X.X.X
+
+  - type: textarea
+    id: environment
+    validations:
+      required: true
+    attributes:
+      label: Browser/OS/Node environment
+      description: |
+        Please list which browser and operating system combination(s) you are using, and/or if this bug affects a command-line tool, please list your Node and npm versions.
+      placeholder: |
+        Browser: Chrome 103.0.5060.53
+        OS: macOS 12.4
+        Node version: 16.15.0
+        npm version: 8.11.0

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Questions, Help, and Advice
+    url: https://github.com/material-components/material-web/discussions
+    about: For general support, please refer to the Material Web discussion board.
+
+  - name: 💬 Chat
+    url: https://lit.dev/discord/
+    about: Alternatively, you can join the Lit Discord and join the \#material channel to talk to the material community and team.

--- a/.github/ISSUE_TEMPLATE/documentation-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation-bug.yaml
@@ -15,8 +15,6 @@ body:
 
   - type: textarea
     id: environment
-    validations:
-      required: true
     attributes:
       label: Browser/OS Environment
       description: |

--- a/.github/ISSUE_TEMPLATE/documentation-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation-bug.yaml
@@ -1,0 +1,26 @@
+name: 🐛 Documentation Bug
+description: Report a bug that affects Material Web documentation (https://material-web.dev/)
+
+body:
+  - type: textarea
+    id: description
+    validations:
+      required: true
+    attributes:
+      label: Description
+      description: |
+        Please describe the documentation issue in as much detail as possible.
+      placeholder: |
+        Add issue description here.
+
+  - type: textarea
+    id: environment
+    validations:
+      required: true
+    attributes:
+      label: Browser/OS Environment
+      description: |
+        Please list which browser and operating system combination(s) you are using.
+      placeholder: |
+        Browser: Chrome 103.0.5060.53
+        OS: macOS 12.4


### PR DESCRIPTION
### Context

This provides a scaffold for folk to fill in bug reports.

This PR adds the following when someone clicks on "file an issue":
 - Bug template, which tries to capture many details about a bug.
 - Documentation bug template, for documentation issues and issues with `material-web.dev`.
 - "Questions, Help, and Advice" section that links to https://github.com/material-components/material-web/discussions
 - "💬 Chat" section that links to the Discord.

### Test plan

This was not tested. But it was closely based on https://github.com/aomarks/issue-template-test/tree/main/.github/ISSUE_TEMPLATE

### Omitted

I omitted "feature-requests" template because I wasn't sure how to structure it. I also omitted a free-form "other" template that allows someone a little less structure if needed. In the short term these can be handled in discussions.
