### PR TITLE
chore(textfield): Add cols attribute to type textarea

### DIFF
--- a/textfield/internal/text-field.ts
+++ b/textfield/internal/text-field.ts
@@ -626,7 +626,7 @@ export abstract class TextField extends LitElement {
           ?readonly=${this.readOnly}
           ?required=${this.required}
           rows=${this.rows}
-		cols=${this.cols}
+          cols=${this.cols}
           .value=${live(this.value)}
           @change=${this.handleChange}
           @focusin=${this.handleFocusin}

--- a/textfield/internal/text-field.ts
+++ b/textfield/internal/text-field.ts
@@ -107,6 +107,11 @@ export abstract class TextField extends LitElement {
    * Defaults to 2.
    */
   @property({type: Number}) rows = 2;
+  /**
+   * The number of cols to display for a `type="textarea"` text field.
+   * Defaults to 20.
+   */
+  @property({type: Number}) cols = 20;
 
   /**
    * The associated form element with which this element's value will submit.
@@ -621,6 +626,7 @@ export abstract class TextField extends LitElement {
           ?readonly=${this.readOnly}
           ?required=${this.required}
           rows=${this.rows}
+		cols=${this.cols}
           .value=${live(this.value)}
           @change=${this.handleChange}
           @focusin=${this.handleFocusin}


### PR DESCRIPTION
Currently the `cols` attribute is not properly relayed to the internal textarea element (https://lit.dev/playground/#gist=2f70901d7332c1885824046a20046596)

This change adds the possibility to use the `cols` attribute.