### PR TITLE
fix(md-item): exclude start slot from hidden overflow

### DIFF
--- a/labs/item/internal/_item.scss
+++ b/labs/item/internal/_item.scss
@@ -85,7 +85,7 @@
   }
 
   .default-slot,
-  :not([name='start'])::slotted(*) {
+  .text ::slotted(*) {
     overflow: hidden;
     text-overflow: ellipsis;
   }

--- a/labs/item/internal/_item.scss
+++ b/labs/item/internal/_item.scss
@@ -85,7 +85,7 @@
   }
 
   .default-slot,
-  ::slotted(*) {
+  :not([name='start'])::slotted(*) {
     overflow: hidden;
     text-overflow: ellipsis;
   }


### PR DESCRIPTION
fixes https://github.com/material-components/material-web/issues/5011

I found this solution, which is excluding the start slot from this css block, the start slot generally will contain icons or similar square-ish elements (e.g. checkbox) so this rule doesn't really need to be applied on this one.
Also, users can always set `overflow: hidden` manually on the element if they want to.

**One rock two birds!**
This PR also fixes another problem that I was about to report, if checkbox is used as a `start` slot the focus ring is not appearing. I just realize the reason the focus ring is not appearing is because the overflow is hidden, it makes sense.