### PR TITLE
Changed linear-progress width: 80px to min-width: 80px to allow resizing again.

### DIFF
--- a/progress/internal/_linear-progress.scss
+++ b/progress/internal/_linear-progress.scss
@@ -43,7 +43,7 @@ $_indeterminate-duration: 2s;
     position: relative;
     // note, this matches the `meter` element and is just done so
     // there's a default width.
-    width: 80px;
+    min-width: 80px;
     height: var(--_track-height);
     content-visibility: auto;
     contain: strict;


### PR DESCRIPTION
See https://github.com/material-components/material-web/issues/5042