### PR TITLE
fix: added formDisabledCallback for formAssociated elements

### DIFF
--- a/button/internal/button.ts
+++ b/button/internal/button.ts
@@ -107,7 +107,7 @@ export abstract class Button extends LitElement implements FormSubmitter {
 
   protected override render() {
     // Link buttons may not be disabled
-    const isDisabled = this.disabled && !this.href;
+    const isDisabled = this.shouldBeDisabled && !this.href;
 
     const button = this.href ? literal`a` : literal`button`;
     // Needed for closure conformance
@@ -163,5 +163,24 @@ export abstract class Button extends LitElement implements FormSubmitter {
 
   private handleSlotChange() {
     this.hasIcon = this.assignedIcons.length > 0;
+  }
+  
+  /**
+   * Whether the element should be disabled either through its own `disabled` or
+   * its formDisabled.
+   */
+  private get shouldBeDisabled() {
+    return this.disabled || this.formDisabled;
+  }
+  
+  /**
+   * Whether the element is currently disabled due to form state.
+   */
+  private formDisabled = false;
+
+  /** @private */
+  formDisabledCallback(formDisabled: boolean) {
+    this.formDisabled = formDisabled;
+    this.requestUpdate();
   }
 }

--- a/checkbox/internal/checkbox.ts
+++ b/checkbox/internal/checkbox.ts
@@ -199,7 +199,7 @@ export class Checkbox extends LitElement {
     if (changed.has('checked') || changed.has('disabled') ||
         changed.has('indeterminate')) {
       this.prevChecked = changed.get('checked') ?? this.checked;
-      this.prevDisabled = changed.get('disabled') ?? this.disabled;
+      this.prevDisabled = changed.get('disabled') ?? this.shouldBeDisabled;
       this.prevIndeterminate =
           changed.get('indeterminate') ?? this.indeterminate;
     }
@@ -218,7 +218,7 @@ export class Checkbox extends LitElement {
     const isIndeterminate = this.indeterminate;
 
     const containerClasses = classMap({
-      'disabled': this.disabled,
+      'disabled': this.shouldBeDisabled,
       'selected': isChecked || isIndeterminate,
       'unselected': !isChecked && !isIndeterminate,
       'checked': isChecked,
@@ -240,7 +240,7 @@ export class Checkbox extends LitElement {
           aria-checked=${isIndeterminate ? 'mixed' : nothing}
           aria-label=${ariaLabel || nothing}
           aria-invalid=${ariaInvalid || nothing}
-          ?disabled=${this.disabled}
+          ?disabled=${this.shouldBeDisabled}
           ?required=${this.required}
           .indeterminate=${this.indeterminate}
           .checked=${this.checked}
@@ -250,7 +250,7 @@ export class Checkbox extends LitElement {
         <div class="outline"></div>
         <div class="background"></div>
         <md-focus-ring part="focus-ring" for="input"></md-focus-ring>
-        <md-ripple for="input" ?disabled=${this.disabled}></md-ripple>
+        <md-ripple for="input" ?disabled=${this.shouldBeDisabled}></md-ripple>
         <svg class="icon" viewBox="0 0 18 18" aria-hidden="true">
           <rect class="mark short" />
           <rect class="mark long" />
@@ -314,5 +314,24 @@ export class Checkbox extends LitElement {
   /** @private */
   formStateRestoreCallback(state: string) {
     this.checked = state === 'true';
+  }
+
+  /**
+   * Whether the element should be disabled either through its own `disabled` or
+   * its formDisabled.
+   */
+  private get shouldBeDisabled() {
+    return this.disabled || this.formDisabled;
+  }
+
+  /**
+   * Whether the element is currently disabled due to form state.
+   */
+  private formDisabled = false;
+
+  /** @private */
+  formDisabledCallback(formDisabled: boolean) {
+    this.formDisabled = formDisabled;
+    this.requestUpdate();
   }
 }

--- a/iconbutton/internal/icon-button.ts
+++ b/iconbutton/internal/icon-button.ts
@@ -132,7 +132,7 @@ export class IconButton extends LitElement implements FormSubmitter {
         aria-haspopup="${!this.href && ariaHasPopup || nothing}"
         aria-expanded="${!this.href && ariaExpanded || nothing}"
         aria-pressed="${ariaPressedValue}"
-        ?disabled="${!this.href && this.disabled}"
+        ?disabled="${!this.href && this.shouldBeDisabled}"
         @click="${this.handleClick}">
         ${this.renderFocusRing()}
         ${this.renderRipple()}
@@ -184,7 +184,7 @@ export class IconButton extends LitElement implements FormSubmitter {
   private renderRipple() {
     return html`<md-ripple
       for=${this.href ? 'link' : nothing}
-      ?disabled="${!this.href && this.disabled}"
+      ?disabled="${!this.href && this.shouldBeDisabled}"
     ></md-ripple>`;
   }
 
@@ -196,7 +196,7 @@ export class IconButton extends LitElement implements FormSubmitter {
   private async handleClick(event: Event) {
     // Allow the event to propagate
     await 0;
-    if (!this.toggle || this.disabled || event.defaultPrevented) {
+    if (!this.toggle || this.shouldBeDisabled || event.defaultPrevented) {
       return;
     }
 
@@ -206,5 +206,24 @@ export class IconButton extends LitElement implements FormSubmitter {
     // Bubbles but does not compose to mimic native browser <input> & <select>
     // Additionally, native change event is not an InputEvent.
     this.dispatchEvent(new Event('change', {bubbles: true}));
+  }
+
+  /**
+   * Whether the element should be disabled either through its own `disabled` or
+   * its formDisabled.
+   */
+  private get shouldBeDisabled() {
+    return this.disabled || this.formDisabled;
+  }
+  
+  /**
+   * Whether the element is currently disabled due to form state.
+   */
+  private formDisabled = false;
+
+  /** @private */
+  formDisabledCallback(formDisabled: boolean) {
+    this.formDisabled = formDisabled;
+    this.requestUpdate();
   }
 }

--- a/radio/internal/radio.ts
+++ b/radio/internal/radio.ts
@@ -114,7 +114,7 @@ export class Radio extends LitElement {
     return html`
       <div class="container ${classMap(classes)}" aria-hidden="true">
         <md-ripple part="ripple" .control=${this}
-            ?disabled=${this.disabled}></md-ripple>
+            ?disabled=${this.shouldBeDisabled}></md-ripple>
         <md-focus-ring part="focus-ring" .control=${this}></md-focus-ring>
         <svg class="icon" viewBox="0 0 20 20">
           <mask id="${this.maskId}">
@@ -132,7 +132,7 @@ export class Radio extends LitElement {
           tabindex="-1"
           .checked=${this.checked}
           .value=${this.value}
-          ?disabled=${this.disabled}
+          ?disabled=${this.shouldBeDisabled}
         >
       </div>
     `;
@@ -143,7 +143,7 @@ export class Radio extends LitElement {
   }
 
   private async handleClick(event: Event) {
-    if (this.disabled) {
+    if (this.shouldBeDisabled) {
       return;
     }
 
@@ -184,5 +184,24 @@ export class Radio extends LitElement {
   /** @private */
   formStateRestoreCallback(state: string) {
     this.checked = state === 'true';
+  }
+
+  /**
+   * Whether the element should be disabled either through its own `disabled` or
+   * its formDisabled.
+   */
+  private get shouldBeDisabled() {
+    return this.disabled || this.formDisabled;
+  }
+  
+  /**
+   * Whether the element is currently disabled due to form state.
+   */
+  private formDisabled = false;
+
+  /** @private */
+  formDisabledCallback(formDisabled: boolean) {
+    this.formDisabled = formDisabled;
+    this.requestUpdate();
   }
 }

--- a/select/internal/select.ts
+++ b/select/internal/select.ts
@@ -414,7 +414,7 @@ export abstract class Select extends LitElement {
 
   private getRenderClasses() {
     return {
-      'disabled': this.disabled,
+      'disabled': this.shouldBeDisabled,
       'error': this.error,
       'open': this.open,
     };
@@ -428,7 +428,7 @@ export abstract class Select extends LitElement {
           role="combobox"
           part="field"
           id="field"
-          tabindex=${this.disabled ? '-1' : '0'}
+          tabindex=${this.shouldBeDisabled ? '-1' : '0'}
           aria-label=${(this as ARIAMixinStrict).ariaLabel || nothing}
           aria-describedby="description"
           aria-expanded=${this.open ? 'true' : nothing}
@@ -437,7 +437,7 @@ export abstract class Select extends LitElement {
           label=${this.label}
           .focused=${this.focused || this.open}
           .populated=${!!this.displayText}
-          .disabled=${this.disabled}
+          .disabled=${this.shouldBeDisabled}
           .required=${this.required}
           .error=${this.hasError}
           ?has-start=${this.hasLeadingIcon}
@@ -525,7 +525,7 @@ export abstract class Select extends LitElement {
    * is closed.
    */
   private handleKeydown(event: KeyboardEvent) {
-    if (this.open || this.disabled || !this.menu) {
+    if (this.open || this.shouldBeDisabled || !this.menu) {
       return;
     }
 
@@ -819,5 +819,24 @@ export abstract class Select extends LitElement {
   /** @private */
   formStateRestoreCallback(state: string) {
     this.value = state;
+  }
+
+  /**
+   * Whether the element should be disabled either through its own `disabled` or
+   * its formDisabled.
+   */
+  private get shouldBeDisabled() {
+    return this.disabled || this.formDisabled;
+  }
+  
+  /**
+   * Whether the element is currently disabled due to form state.
+   */
+  private formDisabled = false;
+
+  /** @private */
+  formDisabledCallback(formDisabled: boolean) {
+    this.formDisabled = formDisabled;
+    this.requestUpdate();
   }
 }

--- a/slider/internal/slider.ts
+++ b/slider/internal/slider.ts
@@ -434,8 +434,8 @@ export class Slider extends LitElement {
 
   private renderHandle({start, hover, label}:
                            {start: boolean, hover: boolean, label: string}) {
-    const onTop = !this.disabled && start === this.startOnTop;
-    const isOverlapping = !this.disabled && this.handlesOverlapping;
+    const onTop = !this.shouldBeDisabled && start === this.startOnTop;
+    const isOverlapping = !this.shouldBeDisabled && this.handlesOverlapping;
     const name = start ? 'start' : 'end';
     return html`<div class="handle ${classMap({
       [name]: true,
@@ -447,7 +447,7 @@ export class Slider extends LitElement {
       ${when(this.labeled, () => this.renderLabel(label))}
       <md-focus-ring part="focus-ring" for=${name}></md-focus-ring>
       <md-ripple for=${name} class=${name} ?disabled=${
-        this.disabled}></md-ripple>
+        this.shouldBeDisabled}></md-ripple>
     </div>`;
   }
 
@@ -478,7 +478,7 @@ export class Slider extends LitElement {
       @input=${this.handleInput}
       @change=${this.handleChange}
       id=${name}
-      .disabled=${this.disabled}
+      .disabled=${this.shouldBeDisabled}
       .min=${String(this.min)}
       aria-valuemin=${ariaMin}
       .max=${String(this.max)}
@@ -543,8 +543,8 @@ export class Slider extends LitElement {
     // Since handle moves to pointer on down and there may not be a move,
     // it needs to be considered hovered..
     this.handleStartHover =
-        !this.disabled && isStart && Boolean(this.handleStart);
-    this.handleEndHover = !this.disabled && !isStart && Boolean(this.handleEnd);
+        !this.shouldBeDisabled && isStart && Boolean(this.handleStart);
+    this.handleEndHover = !this.shouldBeDisabled && !isStart && Boolean(this.handleEnd);
   }
 
   private async handleUp(event: PointerEvent) {
@@ -583,8 +583,8 @@ export class Slider extends LitElement {
    * slider is updated.
    */
   private handleMove(event: PointerEvent) {
-    this.handleStartHover = !this.disabled && inBounds(event, this.handleStart);
-    this.handleEndHover = !this.disabled && inBounds(event, this.handleEnd);
+    this.handleStartHover = !this.shouldBeDisabled && inBounds(event, this.handleStart);
+    this.handleEndHover = !this.shouldBeDisabled && inBounds(event, this.handleEnd);
   }
 
   private handleEnter(event: PointerEvent) {
@@ -734,6 +734,25 @@ export class Slider extends LitElement {
 
     this.value = Number(state);
     this.range = false;
+  }
+
+  /**
+   * Whether the element should be disabled either through its own `disabled` or
+   * its formDisabled.
+   */
+  private get shouldBeDisabled() {
+    return this.disabled || this.formDisabled;
+  }
+  
+  /**
+   * Whether the element is currently disabled due to form state.
+   */
+  private formDisabled = false;
+
+  /** @private */
+  formDisabledCallback(formDisabled: boolean) {
+    this.formDisabled = formDisabled;
+    this.requestUpdate();
   }
 }
 

--- a/switch/internal/switch.ts
+++ b/switch/internal/switch.ts
@@ -216,7 +216,7 @@ export class Switch extends LitElement {
           role="switch"
           aria-label=${(this as ARIAMixin).ariaLabel || nothing}
           ?checked=${this.selected}
-          ?disabled=${this.disabled}
+          ?disabled=${this.shouldBeDisabled}
           ?required=${this.required}
           @change=${this.handleChange}
         >
@@ -239,7 +239,7 @@ export class Switch extends LitElement {
     return {
       'selected': this.selected,
       'unselected': !this.selected,
-      'disabled': this.disabled,
+      'disabled': this.shouldBeDisabled,
     };
   }
 
@@ -250,7 +250,7 @@ export class Switch extends LitElement {
     return html`
       ${this.renderTouchTarget()}
       <span class="handle-container">
-        <md-ripple for="switch" ?disabled="${this.disabled}"></md-ripple>
+        <md-ripple for="switch" ?disabled="${this.shouldBeDisabled}"></md-ripple>
         <span class="handle ${classMap(classes)}">
           ${this.shouldShowIcons() ? this.renderIcons() : html``}
         </span>
@@ -344,5 +344,24 @@ export class Switch extends LitElement {
   /** @private */
   formStateRestoreCallback(state: string) {
     this.selected = state === 'true';
+  }
+
+  /**
+   * Whether the element should be disabled either through its own `disabled` or
+   * its formDisabled.
+   */
+  private get shouldBeDisabled() {
+    return this.disabled || this.formDisabled;
+  }
+  
+  /**
+   * Whether the element is currently disabled due to form state.
+   */
+  private formDisabled = false;
+
+  /** @private */
+  formDisabledCallback(formDisabled: boolean) {
+    this.formDisabled = formDisabled;
+    this.requestUpdate();
   }
 }

--- a/textfield/internal/text-field.ts
+++ b/textfield/internal/text-field.ts
@@ -526,8 +526,8 @@ export abstract class TextField extends LitElement {
 
   protected override render() {
     const classes = {
-      'disabled': this.disabled,
-      'error': !this.disabled && this.hasError,
+      'disabled': this.shouldBeDisabled,
+      'error': !this.shouldBeDisabled && this.hasError,
       'textarea': this.type === 'textarea',
     };
 
@@ -561,7 +561,7 @@ export abstract class TextField extends LitElement {
     return staticHtml`<${this.fieldTag}
       class="field"
       count=${this.value.length}
-      ?disabled=${this.disabled}
+      ?disabled=${this.shouldBeDisabled}
       ?error=${this.hasError}
       error-text=${this.getErrorText()}
       ?focused=${this.focused}
@@ -614,7 +614,7 @@ export abstract class TextField extends LitElement {
           aria-invalid=${this.hasError}
           aria-label=${ariaLabel}
           autocomplete=${autocomplete || nothing}
-          ?disabled=${this.disabled}
+          ?disabled=${this.shouldBeDisabled}
           maxlength=${this.maxLength > -1 ? this.maxLength : nothing}
           minlength=${this.minLength > -1 ? this.minLength : nothing}
           placeholder=${this.placeholder || nothing}
@@ -648,7 +648,7 @@ export abstract class TextField extends LitElement {
           aria-invalid=${this.hasError}
           aria-label=${ariaLabel}
           autocomplete=${autocomplete || nothing}
-          ?disabled=${this.disabled}
+          ?disabled=${this.shouldBeDisabled}
           inputmode=${inputMode || nothing}
           max=${(this.max || nothing) as unknown as number}
           maxlength=${this.maxLength > -1 ? this.maxLength : nothing}
@@ -778,5 +778,24 @@ export abstract class TextField extends LitElement {
   /** @private */
   formStateRestoreCallback(state: string) {
     this.value = state;
+  }
+
+  /**
+   * Whether the element should be disabled either through its own `disabled` or
+   * its formDisabled.
+   */
+  private get shouldBeDisabled() {
+    return this.disabled || this.formDisabled;
+  }
+  
+  /**
+   * Whether the element is currently disabled due to form state.
+   */
+  private formDisabled = false;
+
+  /** @private */
+  formDisabledCallback(formDisabled: boolean) {
+    this.formDisabled = formDisabled;
+    this.requestUpdate();
   }
 }


### PR DESCRIPTION
Controls should be disabled when a parent `fieldset` has `disabled=true`. Fix #5049

![image](https://github.com/material-components/material-web/assets/6388546/a4d9d499-f72d-4292-b0fa-3e443cbd4a8c)
