### PR TITLE
fix(catalog): center items in blockquotes

### DIFF
--- a/catalog/site/css/md-layout.css
+++ b/catalog/site/css/md-layout.css
@@ -207,7 +207,6 @@ main > blockquote:not(catalog-component-header, details) {
   border-radius: var(--catalog-shape-l);
   background-color: var(--md-sys-color-secondary-container);
   display: flex;
-  align-items: center;
   gap: var(--catalog-spacing-s);
 }
 
@@ -216,7 +215,7 @@ main > blockquote:not(catalog-component-header, details) .content {
 }
 
 blockquote .content > *:first-child {
-  margin-block-start: 0;
+  margin-block-start: 4px;
 }
 
 blockquote .content > *:last-child {

--- a/catalog/site/css/md-layout.css
+++ b/catalog/site/css/md-layout.css
@@ -207,6 +207,7 @@ main > blockquote:not(catalog-component-header, details) {
   border-radius: var(--catalog-shape-l);
   background-color: var(--md-sys-color-secondary-container);
   display: flex;
+  align-items: center;
   gap: var(--catalog-spacing-s);
 }
 


### PR DESCRIPTION
Elements are not properly centered in blockquotes I noticed:

![image](https://github.com/material-components/material-web/assets/2827383/67a8f592-34b9-4f43-8056-53711a3bc82c)


