### PR TITLE
docs(progress): corrected buffer value description

### DIFF
--- a/docs/components/progress.md
+++ b/docs/components/progress.md
@@ -388,7 +388,7 @@ Token                                          | Default value
 
 Property | Attribute | Type | Default | Description
 --- | --- | --- | --- | ---
-`buffer` | `buffer` | `number` | `1` | Buffer amount to display, a fraction between 0 and 1.
+`buffer` | `buffer` | `number` | `1` | Buffer amount to display, a fraction between 0 and `max`.
 `value` | `value` | `number` | `0` | Progress to display, a fraction between 0 and `max`.
 `max` | `max` | `number` | `1` | Maximum progress to display, defaults to 1.
 `indeterminate` | `indeterminate` | `boolean` | `false` | Whether or not to display indeterminate progress, which gives no indication to how long an activity will take.

--- a/progress/internal/linear-progress.ts
+++ b/progress/internal/linear-progress.ts
@@ -15,7 +15,7 @@ import {Progress} from './progress.js';
  */
 export class LinearProgress extends Progress {
   /**
-   * Buffer amount to display, a fraction between 0 and max.
+   * Buffer amount to display, a fraction between 0 and `max`.
    */
   @property({type: Number}) buffer = 1;
 

--- a/progress/internal/linear-progress.ts
+++ b/progress/internal/linear-progress.ts
@@ -15,7 +15,7 @@ import {Progress} from './progress.js';
  */
 export class LinearProgress extends Progress {
   /**
-   * Buffer amount to display, a fraction between 0 and 1.
+   * Buffer amount to display, a fraction between 0 and max.
    */
   @property({type: Number}) buffer = 1;
 


### PR DESCRIPTION
Currently the doc says `<md-linear-progress>`'s `buffer`: 

> Buffer amount to display, a fraction between 0 and 1.

This is incorrect. It should be between 0 and **`max`** like `value`. See [Lit playground](https://lit.dev/playground/#project=W3sibmFtZSI6InNpbXBsZS1ncmVldGluZy50cyIsImNvbnRlbnQiOiJpbXBvcnQgXCJAbWF0ZXJpYWwvd2ViL2FsbFwiOyJ9LHsibmFtZSI6ImluZGV4Lmh0bWwiLCJjb250ZW50IjoiPCFET0NUWVBFIGh0bWw-XG48aGVhZD5cbiAgPHNjcmlwdCB0eXBlPVwibW9kdWxlXCIgc3JjPVwiLi9zaW1wbGUtZ3JlZXRpbmcuanNcIj48L3NjcmlwdD5cbjwvaGVhZD5cbjxib2R5PlxuICA8bWQtbGluZWFyLXByb2dyZXNzIG1heD1cIjEwMFwiIHZhbHVlPVwiNTBcIiBidWZmZXI9XCIwLjc1XCI-PC9tZC1saW5lYXItcHJvZ3Jlc3M-XG4gIFxuICA8aHIgLz5cbiAgXG4gIDxtZC1saW5lYXItcHJvZ3Jlc3MgbWF4PVwiMTAwXCIgdmFsdWU9XCI1MFwiIGJ1ZmZlcj1cIjc1XCI-PC9tZC1saW5lYXItcHJvZ3Jlc3M-ICBcbjwvYm9keT5cbiJ9LHsibmFtZSI6InBhY2thZ2UuanNvbiIsImNvbnRlbnQiOiJ7XG4gIFwiZGVwZW5kZW5jaWVzXCI6IHtcbiAgICBcImxpdFwiOiBcIl4zLjAuMC1wcmUuMVwiLFxuICAgIFwiQGxpdC9yZWFjdGl2ZS1lbGVtZW50XCI6IFwiXjIuMC4wLXByZS4xXCIsXG4gICAgXCJsaXQtZWxlbWVudFwiOiBcIl40LjAuMC1wcmUuMVwiLFxuICAgIFwibGl0LWh0bWxcIjogXCJeMy4wLjAtcHJlLjFcIlxuICB9XG59IiwiaGlkZGVuIjp0cnVlfV0) or https://blazorwebmaterial.lukevo.com/progress

![image](https://github.com/material-components/material-web/assets/6388546/807daa3e-b1e9-4831-921f-930db5e35526)


