### PR TITLE
feat(icon): add `--md-icon-size` token

### DIFF
--- a/docs/components/icon.md
+++ b/docs/components/icon.md
@@ -141,8 +141,9 @@ If using SVG icons, add an `aria-label` attribute to the SVG element.
 Token            | Default value
 ---------------- | -----------------------------
 `--md-icon-font` | `'Material Symbols Outlined'`
+`--md-icon-size` | `24px`
 
-*   [All tokens](https://github.com/material-components/material-web/blob/main/icon/internal/_md-comp-icon.scss)
+*   [All tokens](https://github.com/material-components/material-web/blob/main/tokens/_md-comp-icon.scss)
     <!-- {.external} -->
 
 ### Example
@@ -157,13 +158,7 @@ Token            | Default value
 <style>
 md-icon {
   color: #006A6A;
-  font-size: 48px;
-}
-md-icon,
-md-icon > * {
-  /* Resizes any slotted images or SVGs */
-  width: 48px;
-  height: 48px;
+  --md-icon-size: 48px;
 }
 .rounded {
   --md-icon-font: 'Material Symbols Rounded';

--- a/icon/internal/_icon.scss
+++ b/icon/internal/_icon.scss
@@ -32,11 +32,13 @@
   }
 
   :host {
-    font-size: map.get($tokens, size);
+    font-size: map.get($tokens, 'size');
+    width: map.get($tokens, 'size');
+    height: map.get($tokens, 'size');
     color: inherit;
     font-variation-settings: inherit;
     font-weight: 400;
-    font-family: map.get($tokens, font);
+    font-family: map.get($tokens, 'font');
     display: inline-flex;
     font-style: normal;
     line-height: 1;

--- a/icon/internal/_icon.scss
+++ b/icon/internal/_icon.scss
@@ -33,8 +33,6 @@
 
   :host {
     font-size: map.get($tokens, size);
-    width: 24px;
-    height: 24px;
     color: inherit;
     font-variation-settings: inherit;
     font-weight: 400;

--- a/icon/internal/_icon.scss
+++ b/icon/internal/_icon.scss
@@ -32,13 +32,13 @@
   }
 
   :host {
-    font-size: var(--md-icon-size, #{map.get($tokens, size)});
+    font-size: map.get($tokens, size);
     width: 24px;
     height: 24px;
     color: inherit;
     font-variation-settings: inherit;
     font-weight: 400;
-    font-family: var(--md-icon-font, #{map.get($tokens, font)});
+    font-family: map.get($tokens, font);
     display: inline-flex;
     font-style: normal;
     line-height: 1;

--- a/icon/internal/_icon.scss
+++ b/icon/internal/_icon.scss
@@ -27,9 +27,12 @@
 
 @mixin styles() {
   $tokens: tokens.md-comp-icon-values();
+  @each $token, $value in $tokens {
+    $tokens: map.set($tokens, $token, var(--md-icon-#{$token}, #{$value}));
+  }
 
   :host {
-    font-size: 24px;
+    font-size: var(--md-icon-size, #{map.get($tokens, size)});
     width: 24px;
     height: 24px;
     color: inherit;

--- a/tokens/_md-comp-icon.scss
+++ b/tokens/_md-comp-icon.scss
@@ -18,7 +18,7 @@ $supported-tokens: (
   @return (
     // go/keep-sorted start
     font: if($exclude-hardcoded-values, null, 'Material Symbols Outlined'),
-    size: if($exclude-hardcoded-values, null, '24px'),
+    size: if($exclude-hardcoded-values, null, 24px),
     // go/keep-sorted end
   );
 }

--- a/tokens/_md-comp-icon.scss
+++ b/tokens/_md-comp-icon.scss
@@ -10,6 +10,7 @@
 $supported-tokens: (
   // go/keep-sorted start
   'font',
+  'size',
   // go/keep-sorted end
 );
 
@@ -17,6 +18,7 @@ $supported-tokens: (
   @return (
     // go/keep-sorted start
     font: if($exclude-hardcoded-values, null, 'Material Symbols Outlined'),
+    size: if($exclude-hardcoded-values, null, '24px'),
     // go/keep-sorted end
   );
 }


### PR DESCRIPTION
Fixes #5055 

In the old version, the size was controlled by a css variable `font-size: var(--mdc-icon-size, 24px);` Our development is heavily dependent on this to control the size, and the quickest update route is to get back the `md-icon-size` `token`.

Addresses https://github.com/material-components/material-web/issues/5055 see as well https://github.com/material-components/material-web/issues/5055#issuecomment-1791443215 