### PR TITLE
fix(progress): circular progress stretched in flex column display

### DIFF
--- a/progress/internal/_circular-progress.scss
+++ b/progress/internal/_circular-progress.scss
@@ -55,8 +55,8 @@
 
     display: inline-flex;
     vertical-align: middle;
-    min-block-size: var(--_size);
-    min-inline-size: var(--_size);
+    width: var(--_size);
+    height: var(--_size);
     position: relative;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
Fix #5152 

![image](https://github.com/material-components/material-web/assets/6388546/429049bc-f085-4ac1-b79c-afe8ce1f39de)