### PR TITLE
fix(dialog): use margin instead of padding for icon

### DIFF
--- a/dialog/internal/_dialog.scss
+++ b/dialog/internal/_dialog.scss
@@ -150,7 +150,7 @@
     color: var(--_icon-color);
     fill: currentColor;
     font-size: var(--_icon-size);
-    padding-top: 24px;
+    margin-top: 24px;
     height: var(--_icon-size);
     width: var(--_icon-size);
   }


### PR DESCRIPTION
Fixes #5182

The old version hide the md-icon in a md-dialog because of aggressive css rebooting of bootstrap.
My fix is to make the md-icon in md-dialog use margin-top instead of padding-top, and it fix the problem in my browser.

Thank to @christophe-g and @asyncLiz. They give me the opportunity to figure it out and to contribute this PR.