### PR TITLE
docs: broken text field link

### DIFF
--- a/docs/components/text-field.md
+++ b/docs/components/text-field.md
@@ -22,7 +22,7 @@ tag: 'docType:reference'
 
 <!-- external-only-start -->
 **This documentation is fully rendered on the
-[Material Web catalog](https://material-web.dev/components/textfield/)**
+[Material Web catalog](https://material-web.dev/components/text-field/)**
 <!-- external-only-end -->
 
 <!-- no-catalog-end -->


### PR DESCRIPTION
Fix the URL to material-web.dev