### PR TITLE
fix(list-item): hide headline overflow and fix width.

### DIFF
--- a/list/internal/listitem/_list-item.scss
+++ b/list/internal/listitem/_list-item.scss
@@ -73,6 +73,7 @@
     margin: 0;
     text-align: unset;
     text-decoration: none;
+    width: 100%;
   }
 
   .list-item {


### PR DESCRIPTION
fixes https://github.com/material-components/material-web/issues/5219