### PR TITLE
fix(menu): prevent native popover text color from overriding menu surface text color

### DIFF
--- a/menu/internal/_menu.scss
+++ b/menu/internal/_menu.scss
@@ -66,6 +66,7 @@
     overflow: visible;
     // [popover] adds a canvas background
     background-color: transparent;
+    color: inherit;
     opacity: 0;
     z-index: 20;
     position: absolute;


### PR DESCRIPTION
fixes: https://github.com/material-components/material-web/issues/5226