### PR TITLE
feat(switch): add slot icons

### DIFF
--- a/switch/internal/_icon.scss
+++ b/switch/internal/_icon.scss
@@ -25,6 +25,9 @@ $_easing-standard: map.get($_md-sys-motion, 'easing-standard');
       position: absolute;
       inset: 0;
       margin: auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
 
       transition: fill 67ms linear, opacity 33ms linear,
         transform 167ms $_easing-standard;
@@ -45,26 +48,31 @@ $_easing-standard: map.get($_md-sys-motion, 'easing-standard');
       transform: rotate(-45deg);
     }
 
-    .icon--off {
+    .icon--off  {
       width: var(--_icon-size);
       height: var(--_icon-size);
       fill: var(--_icon-color);
+      color: var(--_icon-color);
     }
 
     .unselected:hover .icon--off {
       fill: var(--_hover-icon-color);
+      color: var(--_hover-icon-color);
     }
-
+    
     .unselected:focus-within .icon--off {
       fill: var(--_focus-icon-color);
+      color: var(--_focus-icon-color);
     }
-
+    
     .unselected:active .icon--off {
       fill: var(--_pressed-icon-color);
+      color: var(--_pressed-icon-color);
     }
 
     .unselected.disabled .icon--off {
       fill: var(--_disabled-icon-color);
+      colorr: var(--_disabled-icon-color);
       opacity: var(--_disabled-icon-opacity);
     }
 
@@ -72,22 +80,27 @@ $_easing-standard: map.get($_md-sys-motion, 'easing-standard');
       width: var(--_selected-icon-size);
       height: var(--_selected-icon-size);
       fill: var(--_selected-icon-color);
+      color: var(--_selected-icon-color);
     }
 
     .selected:hover .icon--on {
       fill: var(--_selected-hover-icon-color);
+      color: var(--_selected-hover-icon-color);
     }
 
     .selected:focus-within .icon--on {
       fill: var(--_selected-focus-icon-color);
+      color: var(--_selected-focus-icon-color);
     }
 
     .selected:active .icon--on {
       fill: var(--_selected-pressed-icon-color);
+      color: var(--_selected-pressed-icon-color);
     }
 
     .selected.disabled .icon--on {
       fill: var(--_disabled-selected-icon-color);
+      color: var(--_disabled-selected-icon-color);
       opacity: var(--_disabled-selected-icon-opacity);
     }
   }

--- a/switch/internal/switch.ts
+++ b/switch/internal/switch.ts
@@ -159,10 +159,12 @@ export class Switch extends switchBaseClass {
    */
   private renderOnIcon() {
     return html`
-      <svg class="icon icon--on" viewBox="0 0 24 24">
-        <path
-          d="M9.55 18.2 3.65 12.3 5.275 10.675 9.55 14.95 18.725 5.775 20.35 7.4Z" />
-      </svg>
+      <slot class="icon icon--on" name="on-icon">
+        <svg viewBox="0 0 24 24">
+          <path
+            d="M9.55 18.2 3.65 12.3 5.275 10.675 9.55 14.95 18.725 5.775 20.35 7.4Z" />
+        </svg>
+      </slot>
     `;
   }
 
@@ -171,10 +173,12 @@ export class Switch extends switchBaseClass {
    */
   private renderOffIcon() {
     return html`
-      <svg class="icon icon--off" viewBox="0 0 24 24">
-        <path
-          d="M6.4 19.2 4.8 17.6 10.4 12 4.8 6.4 6.4 4.8 12 10.4 17.6 4.8 19.2 6.4 13.6 12 19.2 17.6 17.6 19.2 12 13.6Z" />
-      </svg>
+      <slot class="icon icon--off" name="off-icon">
+        <svg viewBox="0 0 24 24">
+          <path
+            d="M6.4 19.2 4.8 17.6 10.4 12 4.8 6.4 6.4 4.8 12 10.4 17.6 4.8 19.2 6.4 13.6 12 19.2 17.6 17.6 19.2 12 13.6Z" />
+        </svg>
+      </slot>
     `;
   }
 


### PR DESCRIPTION
As per issue #4549, I added icon slots in `switch` component:

### Example (icons using slots)

```html
<md-switch icons>
  <md-icon slot="off-icon">
    <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M480.028-371q45.428 0 77.2-31.8Q589-434.6 589-480.028t-31.8-77.2Q525.4-589 479.972-589t-77.2 31.8Q371-525.4 371-479.972t31.8 77.2Q434.6-371 480.028-371ZM480-280q-83 0-141.5-58.5T280-480q0-83 58.5-141.5T480-680q83 0 141.5 58.5T680-480q0 83-58.5 141.5T480-280ZM205.5-434.5h-171v-91h171v91Zm720 0h-171v-91h171v91Zm-491-320v-171h91v171h-91Zm0 720v-171h91v171h-91ZM255.761-641.869 147.348-746.522l64.413-67.13 104.13 107.174-60.13 64.609Zm492.478 495.521-105.13-108.174L704-317.652l108.652 104.174-64.413 67.13ZM642.348-704l104.174-108.652 67.13 64.413-107.174 104.13L642.348-704Zm-496 492.239 108.174-105.13L317.652-256 213.478-147.348l-67.13-64.413ZM480-480Z"/></svg>
  </md-icon>
  <md-icon slot="on-icon">
    <svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 -960 960 960" width="24"><path d="M479.958-116.413q-151.477 0-257.511-106.034-106.034-106.034-106.034-257.511 0-151.477 106.046-257.672Q328.505-843.826 480-843.826q13.283 0 26.304.88 13.022.881 25.544 2.881-38.131 29.956-61.076 75.141-22.946 45.185-22.946 97.272 0 91.694 64.325 155.879 64.326 64.186 156.219 64.186 52.608 0 97.413-22.826 44.804-22.826 74.521-60.957 1.761 12.522 2.642 25.235.88 12.712.88 25.896 0 151.435-106.196 257.63-106.195 106.196-257.672 106.196Zm.042-91q81.782 0 147.956-43.717 66.174-43.718 98.413-114.783-17.608 4.044-35.217 6.326-17.609 2.283-34.978 1.805-122.044-4.066-207.946-89.37t-90.446-209.261q-.239-17.369 1.924-34.978t6.446-34.978q-70.826 32.478-114.782 98.652Q207.413-561.543 207.413-480q0 112.929 79.829 192.758Q367.071-207.413 480-207.413Zm-13.109-259.478Z"/></svg>
  </md-icon>
</md-switch>
```

### The Output

#### Off Icon
![image](https://github.com/material-components/material-web/assets/51808724/f5517898-84cb-438f-b050-db6554ad79e1)

#### On Icon
![image](https://github.com/material-components/material-web/assets/51808724/9c372d5b-efaf-41b3-8c3d-2ca265be0caa)

### Example (default icons fallback)

```html
<md-switch icons></md-switch>
```

#### Off Icon
![image](https://github.com/material-components/material-web/assets/51808724/5c3fb355-a0cf-4ad3-a634-07b29e668500)


#### On Icon
![image](https://github.com/material-components/material-web/assets/51808724/8448fd4b-9ac9-4423-b720-f61755e66487)

### Example (no icons)

```html
<md-switch></md-switch>
```

#### Off Icon
![image](https://github.com/material-components/material-web/assets/51808724/219bc3ec-c49f-4df6-8745-a6fbde66fa46)


#### On Icon
![image](https://github.com/material-components/material-web/assets/51808724/9a3642e0-4ca9-4855-94dc-23eb204458b4)



