### PR TITLE
perf(progress): remove hidden animation when dots are not visible

### DIFF
--- a/progress/internal/linear-progress.ts
+++ b/progress/internal/linear-progress.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {html} from 'lit';
+import {html, nothing} from 'lit';
 import {property} from 'lit/decorators.js';
 import {styleMap} from 'lit/directives/style-map.js';
-import {when} from 'lit/directives/when.js';
 
 import {Progress} from './progress.js';
 
@@ -37,7 +36,7 @@ export class LinearProgress extends Progress {
     // only display dots when visible - this prevents invisible infinite animation
     const showDots = !this.indeterminate && (this.buffer >= this.max || this.value >= this.max) ;
     return html`
-      ${when(showDots, () => html`<div class="dots"></div>`)}
+      ${showDots ? html`<div class="dots"></div>` : nothing}
       <div class="inactive-track" style=${styleMap(dotStyles)}></div>
       <div class="bar primary-bar" style=${styleMap(progressStyles)}>
         <div class="bar-inner"></div>

--- a/progress/internal/linear-progress.ts
+++ b/progress/internal/linear-progress.ts
@@ -7,6 +7,7 @@
 import {html} from 'lit';
 import {property} from 'lit/decorators.js';
 import {styleMap} from 'lit/directives/style-map.js';
+import {when} from 'lit/directives/when.js';
 
 import {Progress} from './progress.js';
 
@@ -33,9 +34,10 @@ export class LinearProgress extends Progress {
         (this.indeterminate ? 1 : this.buffer / this.max) * 100
       }%)`,
     };
-
+    // only display dots when visible - this prevents invisible infinite animation
+    const showDots = !this.indeterminate && (this.buffer >= this.max || this.value >= this.max) ;
     return html`
-      <div class="dots"></div>
+      ${when(showDots, () => html`<div class="dots"></div>`)}
       <div class="inactive-track" style=${styleMap(dotStyles)}></div>
       <div class="bar primary-bar" style=${styleMap(progressStyles)}>
         <div class="bar-inner"></div>


### PR DESCRIPTION
Progress has an infinite animation on `<div class="dots">`. `.dots` is only visible when `value` < `max` or `buffer` < `max`. But the animation runs in any case.

Related comment:  https://github.com/material-components/material-web/issues/5251#issuecomment-1858294982