### PR TITLE
fix(progress): progress buffer defaults to 0

### DIFF
--- a/progress/internal/linear-progress.ts
+++ b/progress/internal/linear-progress.ts
@@ -42,7 +42,7 @@ export class LinearProgress extends Progress {
     // Only display dots when visible - this prevents invisible infinite
     // animation.
     const hideDots =
-      this.indeterminate || !hasBuffer || this.value >= this.max;
+      this.indeterminate || !hasBuffer || bufferValue >= this.max || this.value >= this.max;
     return html`
       <div class="dots" ?hidden=${hideDots}></div>
       <div class="inactive-track" style=${styleMap(dotStyles)}></div>

--- a/progress/internal/linear-progress.ts
+++ b/progress/internal/linear-progress.ts
@@ -16,9 +16,9 @@ import {Progress} from './progress.js';
 export class LinearProgress extends Progress {
   /**
    * Buffer amount to display, a fraction between 0 and `max`.
-   * If negative, the buffer is not displayed.
+   * If the value is 0 or negative, the buffer is not displayed.
    */
-  @property({type: Number}) buffer = -1;
+  @property({type: Number}) buffer = 0;
 
   // Note, the indeterminate animation is rendered with transform %'s
   // Previously, this was optimized to use px calculated with the resizeObserver
@@ -29,17 +29,20 @@ export class LinearProgress extends Progress {
         (this.indeterminate ? 1 : this.value / this.max) * 100
       }%)`,
     };
+
+    const bufferValue = Math.min(this.buffer ?? 0, this.max);
+    const hasBuffer = bufferValue > 0;
+
+    const dotSize = this.indeterminate || !hasBuffer ? 1 : bufferValue / this.max;
+
     const dotStyles = {
-      transform: `scaleX(${
-        // == null is used to check for both null and undefined when buffer attribute is removed
-        (this.indeterminate || this.buffer == null || this.buffer < 0 ? 1 : this.buffer / this.max) * 100
-      }%)`,
+      transform: `scaleX(${dotSize * 100}%)`,
     };
 
     // Only display dots when visible - this prevents invisible infinite
     // animation.
     const hideDots =
-      this.indeterminate || this.buffer == null || this.buffer < 0 || this.buffer >= this.max || this.value >= this.max;
+      this.indeterminate || !hasBuffer || this.value >= this.max;
     return html`
       <div class="dots" ?hidden=${hideDots}></div>
       <div class="inactive-track" style=${styleMap(dotStyles)}></div>

--- a/progress/internal/linear-progress.ts
+++ b/progress/internal/linear-progress.ts
@@ -16,8 +16,9 @@ import {Progress} from './progress.js';
 export class LinearProgress extends Progress {
   /**
    * Buffer amount to display, a fraction between 0 and `max`.
+   * If negative, the buffer is not displayed.
    */
-  @property({type: Number}) buffer = 1;
+  @property({type: Number}) buffer = -1;
 
   // Note, the indeterminate animation is rendered with transform %'s
   // Previously, this was optimized to use px calculated with the resizeObserver
@@ -30,14 +31,14 @@ export class LinearProgress extends Progress {
     };
     const dotStyles = {
       transform: `scaleX(${
-        (this.indeterminate ? 1 : this.buffer / this.max) * 100
+        (this.indeterminate || this.buffer < 0 ? 1 : this.buffer / this.max) * 100
       }%)`,
     };
 
     // Only display dots when visible - this prevents invisible infinite
     // animation.
     const hideDots =
-      this.indeterminate || this.buffer >= this.max || this.value >= this.max;
+      this.indeterminate || this.buffer < 0 || this.buffer >= this.max || this.value >= this.max;
     return html`
       <div class="dots" ?hidden=${hideDots}></div>
       <div class="inactive-track" style=${styleMap(dotStyles)}></div>

--- a/progress/internal/linear-progress.ts
+++ b/progress/internal/linear-progress.ts
@@ -31,14 +31,15 @@ export class LinearProgress extends Progress {
     };
     const dotStyles = {
       transform: `scaleX(${
-        (this.indeterminate || this.buffer < 0 ? 1 : this.buffer / this.max) * 100
+        // == null is used to check for both null and undefined when buffer attribute is removed
+        (this.indeterminate || this.buffer == null || this.buffer < 0 ? 1 : this.buffer / this.max) * 100
       }%)`,
     };
 
     // Only display dots when visible - this prevents invisible infinite
     // animation.
     const hideDots =
-      this.indeterminate || this.buffer < 0 || this.buffer >= this.max || this.value >= this.max;
+      this.indeterminate || this.buffer == null || this.buffer < 0 || this.buffer >= this.max || this.value >= this.max;
     return html`
       <div class="dots" ?hidden=${hideDots}></div>
       <div class="inactive-track" style=${styleMap(dotStyles)}></div>

--- a/progress/internal/linear-progress.ts
+++ b/progress/internal/linear-progress.ts
@@ -30,7 +30,7 @@ export class LinearProgress extends Progress {
       }%)`,
     };
 
-    const bufferValue = Math.min(this.buffer ?? 0, this.max);
+    const bufferValue = this.buffer ?? 0;
     const hasBuffer = bufferValue > 0;
 
     const dotSize = this.indeterminate || !hasBuffer ? 1 : bufferValue / this.max;


### PR DESCRIPTION
Fix #5251 .

```html
    <md-linear-progress value="10" max="100"></md-linear-progress>    
    <md-linear-progress value="10" buffer="50" max="100"></md-linear-progress>
```

![image](https://github.com/material-components/material-web/assets/6388546/6a243868-2328-4b9a-9451-30b580c3cb39)
