### PR TITLE
chore(dialog): change animation properties to methods

### DIFF
--- a/dialog/internal/dialog.ts
+++ b/dialog/internal/dialog.ts
@@ -77,13 +77,13 @@ export class Dialog extends LitElement {
    * Gets the opening animation for a dialog. Set to a new function to customize
    * the animation.
    */
-  getOpenAnimation = () => DIALOG_DEFAULT_OPEN_ANIMATION;
+  getOpenAnimation() { return DIALOG_DEFAULT_OPEN_ANIMATION; }
 
   /**
    * Gets the closing animation for a dialog. Set to a new function to customize
    * the animation.
    */
-  getCloseAnimation = () => DIALOG_DEFAULT_CLOSE_ANIMATION;
+  getCloseAnimation() { return DIALOG_DEFAULT_CLOSE_ANIMATION; }
 
   private isOpen = false;
   private isOpening = false;


### PR DESCRIPTION
Moving `getOpenAnimation` and `getCloseAnimation` properties to methods type for the doc:
![image](https://github.com/material-components/material-web/assets/2827383/d99ff1e4-168e-4906-92a4-5e780ffa3758)
