### PR TITLE
fix(textfield): text-align inherits from parent

### DIFF
--- a/textfield/internal/_filled-text-field.scss
+++ b/textfield/internal/_filled-text-field.scss
@@ -36,6 +36,9 @@
   );
 
   :host {
+    // Reset text-align like standard input
+    text-align: start;
+    
     // Only use the logical properties.
     $tokens: map.remove($tokens, 'container-shape');
     @each $token, $value in $tokens {

--- a/textfield/internal/_outlined-text-field.scss
+++ b/textfield/internal/_outlined-text-field.scss
@@ -31,6 +31,9 @@
   );
 
   :host {
+    // Reset text-align like standard input
+    text-align: start;
+
     // Only use the logical properties.
     $tokens: map.remove($tokens, 'container-shape');
     @each $token, $value in $tokens {


### PR DESCRIPTION
Fix #5509 

![image](https://github.com/material-components/material-web/assets/6388546/1bdccfdc-72ee-45b4-bf36-ecdf94fa57ea)

```html
  <div class="container vstack gap-3 text-center border p-3">
    <p>Centered Text</p>

    <md-outlined-text-field value="This text should be at the start"></md-outlined-text-field>
    <md-filled-text-field value="This text should be at the start"></md-filled-text-field>
    <input value="This text should be at the start" />

    <md-outlined-text-field class="text-center" value="This text is manually centered"></md-outlined-text-field>
    <md-filled-text-field class="text-center" value="This text is manually centered"></md-filled-text-field>
    <input class="text-center" value="This text is manually centered" />
  </div>
```