### PR TITLE
docs: fix typo on theming docs

### DIFF
--- a/docs/theming/README.md
+++ b/docs/theming/README.md
@@ -88,14 +88,14 @@ to components. See the [color guide](color.md) for more details.
 
 #### Typography
 
-[`--md-sys-typography` tokens](typography.md#typescale) define typescale roles
+[`--md-sys-typescale` tokens](typography.md#typescale) define typescale roles
 that map to components. See the [typography guide](typography.md) for more
 details.
 
 ```css
 :root {
-  --md-sys-typography-body-medium-size: 1rem;
-  --md-sys-typography-body-medium-line-height: 1.5rem;
+  --md-sys-typescale-body-medium-size: 1rem;
+  --md-sys-typescale-body-medium-line-height: 1.5rem;
 }
 ```
 


### PR DESCRIPTION
There aren't CSS vars prefixed with `--md-sys--typograph`. The correct prefix is `--md-sys--typescale`. See https://github.com/material-components/material-web/blob/main/tokens/_md-sys-typescale.scss#L138.

The "Typography" heading could also be renamed to "Typescale" for consistency with how the section is named in the [Typography page](https://material-web.dev/theming/typography/#typescale). 