### PR TITLE
feat: vertical support for tabs component

### DIFF
--- a/tabs/internal/_tab.scss
+++ b/tabs/internal/_tab.scss
@@ -202,7 +202,10 @@
     .content{
       width: 100%;
       padding: 0 16px;
-    }
+
+      &.has-icon{
+        justify-content: start;
+      }
 
     .indicator {
       inset: 0 0 0 auto;

--- a/tabs/internal/_tab.scss
+++ b/tabs/internal/_tab.scss
@@ -21,7 +21,7 @@
     align-items: center;
     justify-content: center;
     outline: none;
-    padding: 0 16px;
+    padding: 0;
     position: relative;
     -webkit-tap-highlight-color: transparent;
     vertical-align: middle;
@@ -60,6 +60,10 @@
 
   :host([active]) md-focus-ring {
     margin-bottom: calc(var(--_active-indicator-height) + 1px);
+  }
+
+  .button{
+    padding: 0 16px;
   }
 
   .button::before {
@@ -190,6 +194,23 @@
   ::slotted(*) {
     white-space: nowrap;
   }
+
+  .button.vertical {
+    width: 100%;
+    padding: 0;
+
+    .content{
+      width: 100%;
+      padding: 0 16px;
+    }
+
+    .indicator {
+      inset: 0 0 0 auto;
+      width: var(--_active-indicator-height);
+      height: unset;
+    }
+  }
+
 
   @media (forced-colors: active) {
     .indicator {

--- a/tabs/internal/_tabs.scss
+++ b/tabs/internal/_tabs.scss
@@ -44,4 +44,14 @@
   ::slotted([active]) {
     z-index: 1;
   }
+
+  .tabs.vertical {
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: flex-start;
+
+    ::slotted(*) {
+      flex: none;
+    }
+  }
 }

--- a/tabs/internal/tab.ts
+++ b/tabs/internal/tab.ts
@@ -49,6 +49,11 @@ export class Tab extends tabBaseClass {
   readonly isTab = true;
 
   /**
+   * Whether or not the tab is vertical.
+   */
+  @property({type: Boolean}) vertical = false;
+
+  /**
    * Whether or not the tab is selected.
    **/
   @property({type: Boolean, reflect: true}) active = false;
@@ -95,7 +100,7 @@ export class Tab extends tabBaseClass {
   protected override render() {
     const indicator = html`<div class="indicator"></div>`;
     return html`<div
-      class="button"
+      class="button ${this.vertical ? 'vertical' : ''}"
       role="presentation"
       @click=${this.handleContentClick}>
       <md-focus-ring part="focus-ring" inward .control=${this}></md-focus-ring>
@@ -170,11 +175,11 @@ export class Tab extends tabBaseClass {
     const from: Keyframe = {};
     const fromRect =
       previousTab[INDICATOR]?.getBoundingClientRect() ?? ({} as DOMRect);
-    const fromPos = fromRect.left;
-    const fromExtent = fromRect.width;
+    const fromPos = !this.vertical ? fromRect.left : fromRect.top;
+    const fromExtent = !this.vertical ? fromRect.width : fromRect.height;
     const toRect = this[INDICATOR]!.getBoundingClientRect();
-    const toPos = toRect.left;
-    const toExtent = toRect.width;
+    const toPos = !this.vertical ? toRect.left : toRect.top;
+    const toExtent = !this.vertical ? toRect.width : toRect.height;
     const scale = fromExtent / toExtent;
     if (
       !reduceMotion &&
@@ -182,9 +187,9 @@ export class Tab extends tabBaseClass {
       toPos !== undefined &&
       !isNaN(scale)
     ) {
-      from['transform'] = `translateX(${(fromPos - toPos).toFixed(
+      from['transform'] = `translate${(!this.vertical ? 'X' : 'Y')}(${(fromPos - toPos).toFixed(
         4,
-      )}px) scaleX(${scale.toFixed(4)})`;
+      )}px) scale${(!this.vertical ? 'X' : 'Y')}(${scale.toFixed(4)})`;
     } else {
       from['opacity'] = 0;
     }

--- a/tabs/internal/tabs.ts
+++ b/tabs/internal/tabs.ts
@@ -99,6 +99,11 @@ export class Tabs extends LitElement {
   }
 
   /**
+   * Whether the tabs should be displayed vertically.
+   */
+  @property({type: Boolean}) vertical = false;
+
+  /**
    * Whether or not to automatically select a tab when it is focused.
    */
   @property({type: Boolean, attribute: 'auto-activate'}) autoActivate = false;
@@ -149,10 +154,10 @@ export class Tabs extends LitElement {
       await tab.updateComplete;
     }
 
-    const offset = tabToScrollTo.offsetLeft;
-    const extent = tabToScrollTo.offsetWidth;
-    const scroll = this.scrollLeft;
-    const hostExtent = this.offsetWidth;
+    const offset = !this.vertical ? tabToScrollTo.offsetLeft : tabToScrollTo.offsetTop;
+    const extent = !this.vertical ? tabToScrollTo.offsetWidth : tabToScrollTo.offsetHeight;
+    const scroll = !this.vertical ? this.scrollLeft : this.scrollTop;
+    const hostExtent = !this.vertical ? this.offsetWidth : this.offsetHeight;
     const scrollMargin = 48;
     const min = offset - scrollMargin;
     const max = offset + extent - hostExtent + scrollMargin;
@@ -162,17 +167,17 @@ export class Tabs extends LitElement {
     // focused on initialization, use 'instant' to immediately bring the focused
     // tab into view.
     const behavior: ScrollBehavior = !this.focusedTab ? 'instant' : 'auto';
-    this.tabsScrollerElement.scrollTo({behavior, top: 0, left: to});
+    this.tabsScrollerElement.scrollTo({behavior, top: !this.vertical ? 0 : to, left: !this.vertical ? to : 0});
   }
 
   protected override render() {
     return html`
-      <div class="tabs">
+      <div class="tabs ${this.vertical ? 'vertical' : ''}">
         <slot
           @slotchange=${this.handleSlotChange}
           @click=${this.handleTabClick}></slot>
       </div>
-      <md-divider part="divider"></md-divider>
+      ${!this.vertical ? html`<md-divider part="divider"></md-divider>` : ''}
     `;
   }
 
@@ -229,8 +234,8 @@ export class Tabs extends LitElement {
   private async handleKeydown(event: KeyboardEvent) {
     // Allow event to bubble.
     await 0;
-    const isLeft = event.key === 'ArrowLeft';
-    const isRight = event.key === 'ArrowRight';
+    const isLeft = event.key === 'ArrowLeft' || event.key === 'ArrowUp';
+    const isRight = event.key === 'ArrowRight' || event.key === 'ArrowDown';
     const isHome = event.key === 'Home';
     const isEnd = event.key === 'End';
     // Ignore non-navigation keys


### PR DESCRIPTION
I felt like this was missing from tabs component and decided to add possible implementation of mentioned functionality myself. 
To use it just add vertical attribute to `<md-tabs>` and they are displayed vertically with indicator staying on bottom of the individual tabs.
I also added vertical attribute to `<md-primary-tab>` and `<md-secondary-tab>` so the indicator can be put sideways.
The only missing thing is maybe updated documentation.
#5608 