### PR TITLE
feat(textfield): make required asterisk optional

### DIFF
--- a/field/internal/field.ts
+++ b/field/internal/field.ts
@@ -25,6 +25,7 @@ export class Field extends LitElement {
   @property({type: Boolean}) error = false;
   @property({type: Boolean}) focused = false;
   @property() label = '';
+  @property({type: Boolean, attribute: 'no-asterisk'}) noAsterisk = false;
   @property({type: Boolean}) populated = false;
   @property({type: Boolean}) required = false;
   @property({type: Boolean}) resizable = false;
@@ -242,7 +243,9 @@ export class Field extends LitElement {
     };
 
     // Add '*' if a label is present and the field is required
-    const labelText = `${this.label}${this.required ? '*' : ''}`;
+    const labelText = `${this.label}${
+      this.required && !this.noAsterisk ? '*' : ''
+    }`;
 
     return html`
       <span class="label ${classMap(classes)}" aria-hidden=${!visible}

--- a/field/internal/field_test.ts
+++ b/field/internal/field_test.ts
@@ -52,6 +52,7 @@ describe('Field', () => {
     const template = html`
       <md-test-field
         .label=${props.label ?? ''}
+        ?no-asterisk=${props.noAsterisk ?? false}
         ?disabled=${props.disabled ?? false}
         .error=${props.error ?? false}
         .populated=${props.populated ?? false}
@@ -333,6 +334,21 @@ describe('Field', () => {
           'label text should be empty string if label is not provided, even when required',
         )
         .toBe('');
+    });
+
+    it('should not render asterisk if required, but noAsterisk', async () => {
+      // Setup.
+      // Test case.
+      const labelValue = 'Label';
+      const {instance} = await setupTest({
+        required: true, label: labelValue, noAsterisk: true
+      });
+      //Assertion
+      expect(instance.labelText)
+        .withContext(
+          'label test should equal label without asterisk, when required and noAsterisk',
+        )
+        .toBe(labelValue);
     });
   });
 


### PR DESCRIPTION
Makes the required asterisks on text fields.