### PR TITLE
fix(textfield): browser autocomplete works outside of a form

### DIFF
--- a/textfield/internal/text-field.ts
+++ b/textfield/internal/text-field.ts
@@ -604,6 +604,7 @@ export abstract class TextField extends textFieldBaseClass {
           aria-invalid=${this.hasError}
           aria-label=${ariaLabel}
           autocomplete=${autocomplete || nothing}
+          name=${this.name || nothing}
           ?disabled=${this.disabled}
           maxlength=${hasMaxLength ? this.maxLength : nothing}
           minlength=${hasMinLength ? this.minLength : nothing}
@@ -638,6 +639,7 @@ export abstract class TextField extends textFieldBaseClass {
           aria-invalid=${this.hasError}
           aria-label=${ariaLabel}
           autocomplete=${autocomplete || nothing}
+          name=${this.name || nothing}
           ?disabled=${this.disabled}
           inputmode=${inputMode || nothing}
           max=${(this.max || nothing) as unknown as number}


### PR DESCRIPTION
Add name attribute to input and textarea elements created by the text-filed element. 
This enables autocomplete to work int he browser even if a form is not used.
Discussed in issue #4589