### PR TITLE
feat: check for server before creating treewalker from document

### DIFF
--- a/dialog/internal/dialog.ts
+++ b/dialog/internal/dialog.ts
@@ -152,7 +152,7 @@ export class Dialog extends dialogBaseClass {
   // focusable elements. TreeWalker is faster than `querySelectorAll('*')`.
   // We check for isServer because there isn't a "document" during an SSR
   // run.
-  private readonly treewalker = isServer ? {} : document.createTreeWalker(
+  private readonly treewalker = isServer ? {} as TreeWalker : document.createTreeWalker(
     this,
     NodeFilter.SHOW_ELEMENT,
   );

--- a/dialog/internal/dialog.ts
+++ b/dialog/internal/dialog.ts
@@ -150,7 +150,9 @@ export class Dialog extends dialogBaseClass {
   private escapePressedWithoutCancel = false;
   // This TreeWalker is used to walk through a dialog's children to find
   // focusable elements. TreeWalker is faster than `querySelectorAll('*')`.
-  private readonly treewalker = document.createTreeWalker(
+  // We check for isServer because there isn't a "document" during an SSR
+  // run.
+  private readonly treewalker = isServer ? {} : document.createTreeWalker(
     this,
     NodeFilter.SHOW_ELEMENT,
   );

--- a/dialog/internal/dialog.ts
+++ b/dialog/internal/dialog.ts
@@ -564,7 +564,7 @@ export class Dialog extends dialogBaseClass {
   private getFirstAndLastFocusableChildren(): [HTMLElement, HTMLElement]
   | [null, null] {
     if (!this.treewalker) {
-      return [null, null] as const;
+      return [null, null];
     }
 
     let firstFocusableChild: HTMLElement | null = null;

--- a/dialog/internal/dialog.ts
+++ b/dialog/internal/dialog.ts
@@ -152,7 +152,7 @@ export class Dialog extends dialogBaseClass {
   // focusable elements. TreeWalker is faster than `querySelectorAll('*')`.
   // We check for isServer because there isn't a "document" during an SSR
   // run.
-  private readonly treewalker = isServer ? {} as TreeWalker : document.createTreeWalker(
+  private readonly treewalker = isServer ? null : document.createTreeWalker(
     this,
     NodeFilter.SHOW_ELEMENT,
   );
@@ -561,7 +561,12 @@ export class Dialog extends dialogBaseClass {
     // won't actually reach here.
   }
 
-  private getFirstAndLastFocusableChildren() {
+  private getFirstAndLastFocusableChildren(): [HTMLElement, HTMLElement]
+  | [null, null] {
+    if (!this.treewalker) {
+      return [null, null] as const;
+    }
+
     let firstFocusableChild: HTMLElement | null = null;
     let lastFocusableChild: HTMLElement | null = null;
 
@@ -584,9 +589,7 @@ export class Dialog extends dialogBaseClass {
     // We set lastFocusableChild immediately after finding a
     // firstFocusableChild, which means the pair is either both null or both
     // non-null. Cast since TypeScript does not recognize this.
-    return [firstFocusableChild, lastFocusableChild] as
-      | [HTMLElement, HTMLElement]
-      | [null, null];
+    return [firstFocusableChild, lastFocusableChild];
   }
 }
 


### PR DESCRIPTION
Hey, 

I've been trying to get Material Components to work in NextJS SSG. All other components work fine [except for Dialog](https://github.com/grayhatdevelopers/material-web-react/blob/main/apps/demo/src/app/page.tsx#L14), which throws the error `document is not defined`.


Upon inspection, the reason is because Dialog uses document.treeWalker upon initialization. I've added a check to initialize it as an empty object typecasted to TreeWalker, so that it works fine in SSG.

Tested, works ok. However, I'd love to know if there's a better way, instead of typecasting.