### PR TITLE
fix(catalog): clipboard check copy icon not showing

### DIFF
--- a/catalog/src/components/copy-code-button.ts
+++ b/catalog/src/components/copy-code-button.ts
@@ -7,8 +7,8 @@
 import '@material/web/icon/icon.js';
 import '@material/web/iconbutton/icon-button.js';
 
-import { MdIconButton } from '@material/web/iconbutton/icon-button.js';
-import { css, html, LitElement } from 'lit';
+import {MdIconButton} from '@material/web/iconbutton/icon-button.js';
+import {css, html, LitElement} from 'lit';
 import {
   customElement,
   property,
@@ -56,16 +56,16 @@ export class CopyCodeButton extends LitElement {
    * The aria label for the copy button when it has been clicked and the copy is
    * successul.
    */
-  @property({ attribute: 'success-label' }) successLabel = 'Copy successful';
+  @property({attribute: 'success-label'}) successLabel = 'Copy successful';
 
   /**
    * The title to be set on the copy button.
    */
-  @property({ attribute: 'button-title' }) buttonTitle = 'Copy code';
+  @property({attribute: 'button-title'}) buttonTitle = 'Copy code';
 
   @query('md-icon-button') private copyButton!: MdIconButton;
 
-  @queryAssignedElements({ flatten: true, selector: '*' })
+  @queryAssignedElements({flatten: true, selector: '*'})
   private slottedEls!: NodeListOf<HTMLElement>;
 
   render() {

--- a/catalog/src/components/copy-code-button.ts
+++ b/catalog/src/components/copy-code-button.ts
@@ -7,8 +7,8 @@
 import '@material/web/icon/icon.js';
 import '@material/web/iconbutton/icon-button.js';
 
-import {MdIconButton} from '@material/web/iconbutton/icon-button.js';
-import {css, html, LitElement} from 'lit';
+import { MdIconButton } from '@material/web/iconbutton/icon-button.js';
+import { css, html, LitElement } from 'lit';
 import {
   customElement,
   property,
@@ -56,16 +56,16 @@ export class CopyCodeButton extends LitElement {
    * The aria label for the copy button when it has been clicked and the copy is
    * successul.
    */
-  @property({attribute: 'success-label'}) successLabel = 'Copy successful';
+  @property({ attribute: 'success-label' }) successLabel = 'Copy successful';
 
   /**
    * The title to be set on the copy button.
    */
-  @property({attribute: 'button-title'}) buttonTitle = 'Copy code';
+  @property({ attribute: 'button-title' }) buttonTitle = 'Copy code';
 
   @query('md-icon-button') private copyButton!: MdIconButton;
 
-  @queryAssignedElements({flatten: true, selector: '*'})
+  @queryAssignedElements({ flatten: true, selector: '*' })
   private slottedEls!: NodeListOf<HTMLElement>;
 
   render() {
@@ -80,7 +80,7 @@ export class CopyCodeButton extends LitElement {
         aria-label=${this.label}
         aria-label-selected=${this.successLabel}>
         <md-icon>content_copy</md-icon>
-        <md-icon slot="selected">checkmark</md-icon>
+        <md-icon slot="selected">check</md-icon>
       </md-icon-button>
     `;
   }


### PR DESCRIPTION
Fixes #5696

**Description:**

This pull request addresses issue #5696, where the check mark indicating a successful clipboard action did not appear when clicking the clipboard icon in the Material Web UI.

**Changes Made:**

- Updated the icon name from `checkmark` to `check` in the `slot="selected"` for the `md-icon-button` component.

**Details:**

The issue occurred because the `md-icon` component was using an incorrect icon name for the selected state. By changing the icon name to `check`, the check mark now correctly displays upon clicking the clipboard icon, providing the expected visual feedback.

**Testing:**

- Verified that the check mark appears correctly after clicking the clipboard icon.
- Ensured that no other functionalities were affected by this change.

**Related Issue:**

- Fixes #5696  
