### PR TITLE
fix(labs): remove unnecessary CSS duplication variables of components in labs

### DIFF
--- a/labs/badge/internal/_badge.scss
+++ b/labs/badge/internal/_badge.scss
@@ -29,7 +29,7 @@
 
   :host {
     @each $token, $value in $tokens {
-      --_#{$token}: var(--md-badge-#{$token}, #{$value});
+      --_#{$token}: #{$value};
     }
   }
 

--- a/labs/navigationbar/internal/_navigation-bar.scss
+++ b/labs/navigationbar/internal/_navigation-bar.scss
@@ -35,7 +35,7 @@ $_md-sys-motion: tokens.md-sys-motion-values();
 
   :host {
     @each $token, $value in $tokens {
-      --_#{$token}: var(--md-navigation-bar-#{$token}, #{$value});
+      --_#{$token}: #{$value};
     }
 
     @include elevation.theme(

--- a/labs/navigationtab/internal/_navigation-tab.scss
+++ b/labs/navigationtab/internal/_navigation-tab.scss
@@ -38,7 +38,7 @@ $animation-duration: 100ms;
 
   :host {
     @each $token, $value in $tokens {
-      --_#{$token}: var(--md-navigation-bar-#{$token}, #{$value});
+      --_#{$token}: #{$value};
     }
 
     display: flex;

--- a/labs/segmentedbutton/internal/_outlined-segmented-button.scss
+++ b/labs/segmentedbutton/internal/_outlined-segmented-button.scss
@@ -26,7 +26,7 @@
 
   :host {
     @each $token, $value in $tokens {
-      --_#{$token}: var(--md-outlined-segmented-button-#{$token}, #{$value});
+      --_#{$token}: #{$value};
     }
   }
 


### PR DESCRIPTION
I found that some components in the labs folder had duplicate CSS variables (includes badge, navigationbar, navigationtab, segmentedbutton) , like this:

![image](https://github.com/user-attachments/assets/d53ed8dd-0198-4b87-92e1-01ee30858a79)

After I compile the component style separately through sass:

`npx sass ./labs/navigationbar/internal/navigation-bar-styles.scss ./o.css`

![image](https://github.com/user-attachments/assets/5b6c2904-c914-4b2d-8e9e-4e2e6e49371c)

This is because of unnecessary prefixes in these styles:

```scss
    @each $token, $value in $tokens {
      // We need to delete "var(--md-navigation-bar-#{$token}, "
      //--_#{$token}: var(--md-navigation-bar-#{$token}, #{$value});
      --_#{$token}: #{$value};
    }
```

After repair:

![image](https://github.com/user-attachments/assets/2c2f71e7-e4fa-4c5c-b3f8-34f88a62e694)
