### PR TITLE
fix(filter-chip): center trailing icon in its container

### DIFF
--- a/chips/internal/_trailing-icon.scss
+++ b/chips/internal/_trailing-icon.scss
@@ -30,8 +30,11 @@
   }
 
   .trailing.icon {
+    align-items: center;
     color: var(--_trailing-icon-color);
+    display: flex;
     height: var(--_icon-size);
+    justify-content: center;
     width: var(--_icon-size);
   }
 


### PR DESCRIPTION
fixes https://github.com/material-components/material-web/issues/5709