### PR TITLE
Add missing overrides to symbol property methods

### DIFF
--- a/select/internal/select.ts
+++ b/select/internal/select.ts
@@ -311,7 +311,7 @@ export abstract class Select extends selectBaseClass {
     this.nativeErrorText = '';
   }
 
-  [onReportValidity](invalidEvent: Event | null) {
+  override [onReportValidity](invalidEvent: Event | null) {
     // Prevent default pop-up behavior.
     invalidEvent?.preventDefault();
 
@@ -834,11 +834,11 @@ export abstract class Select extends selectBaseClass {
     this.field?.click();
   }
 
-  [createValidator]() {
+  override [createValidator]() {
     return new SelectValidator(() => this);
   }
 
-  [getValidityAnchor]() {
+  override [getValidityAnchor]() {
     return this.field;
   }
 }

--- a/textfield/internal/text-field.ts
+++ b/textfield/internal/text-field.ts
@@ -768,18 +768,18 @@ export abstract class TextField extends textFieldBaseClass {
     this.getInputOrTextarea().focus();
   }
 
-  [createValidator](): Validator<unknown> {
+  override [createValidator](): Validator<unknown> {
     return new TextFieldValidator(() => ({
       state: this,
       renderedControl: this.inputOrTextarea,
     }));
   }
 
-  [getValidityAnchor](): HTMLElement | null {
+  override [getValidityAnchor](): HTMLElement | null {
     return this.inputOrTextarea;
   }
 
-  [onReportValidity](invalidEvent: Event | null) {
+  override [onReportValidity](invalidEvent: Event | null) {
     // Prevent default pop-up behavior.
     invalidEvent?.preventDefault();
 


### PR DESCRIPTION
Without `override` on these, does not compile in TS 5.6