### PR TITLE
This addresses issue # 5728

### DIFF
--- a/textfield/internal/_input.scss
+++ b/textfield/internal/_input.scss
@@ -38,6 +38,11 @@
       display: none;
     }
 
+    // Remove built-in password reveal icon on Microsoft Edge when type='password'
+    &::-ms-reveal {
+      display: none;
+    }
+
     @media (forced-colors: active) {
       background: none; // Remove background in Firefox HCM
     }


### PR DESCRIPTION
Removes the password reveal icon on Microsoft Edge browser.