### PR TITLE
fix(field): field borders now are correctly colored even on Safari

### DIFF
--- a/field/internal/_outlined-field.scss
+++ b/field/internal/_outlined-field.scss
@@ -130,6 +130,7 @@ $_md-sys-motion: tokens.md-sys-motion-values();
     .outline-notch {
       align-items: flex-start;
       border: inherit;
+      border-color: inherit !important;
       display: flex;
       margin-inline-start: calc(-1 * var(--_outline-label-padding));
       margin-inline-end: var(--_outline-label-padding);
@@ -259,7 +260,7 @@ $_md-sys-motion: tokens.md-sys-motion-values();
     }
 
     .focused .outline,
-    .focused .outline-notch{
+    .focused .outline-notch {
       border-color: var(--_focus-outline-color);
       color: var(--_focus-outline-color); // Needed for Firefox HCM
     }

--- a/field/internal/_outlined-field.scss
+++ b/field/internal/_outlined-field.scss
@@ -244,7 +244,8 @@ $_md-sys-motion: tokens.md-sys-motion-values();
 
     // States
 
-    :hover .outline {
+    :hover .outline,
+    :hover .outline-notch {
       border-color: var(--_hover-outline-color);
       color: var(--_hover-outline-color); // Needed for Firefox HCM
     }
@@ -257,7 +258,8 @@ $_md-sys-motion: tokens.md-sys-motion-values();
       border-width: var(--_hover-outline-width);
     }
 
-    .focused .outline {
+    .focused .outline,
+    .focused .outline-notch{
       border-color: var(--_focus-outline-color);
       color: var(--_focus-outline-color); // Needed for Firefox HCM
     }
@@ -270,7 +272,8 @@ $_md-sys-motion: tokens.md-sys-motion-values();
       border-width: var(--_focus-outline-width);
     }
 
-    .disabled .outline {
+    .disabled .outline,
+    .disabled .outline-notch {
       border-color: var(--_disabled-outline-color);
       color: var(--_disabled-outline-color); // Needed for Firefox HCM
     }
@@ -289,18 +292,21 @@ $_md-sys-motion: tokens.md-sys-motion-values();
       border-width: var(--_disabled-outline-width);
     }
 
-    .error .outline {
+    .error .outline,
+    .error .outline-notch {
       border-color: var(--_error-outline-color);
       color: var(--_error-outline-color); // Needed for Firefox HCM
     }
 
-    .error:hover .outline {
+    .error:hover .outline,
+    .error:hover .outline-notch {
       border-color: var(--_error-hover-outline-color);
       // Needed for Firefox HCM
       color: var(--_error-hover-outline-color);
     }
 
-    .error.focused .outline {
+    .error.focused .outline,
+    .error.focused .outline-notch {
       border-color: var(--_error-focus-outline-color);
       // Needed for Firefox HCM
       color: var(--_error-focus-outline-color);


### PR DESCRIPTION
Hi there! This is a small patch to fix an annoying bug that occurs with Fields on Safari, both on macOS and iOS.

As also described in issue #5668, Fields such as `<md-outlined-text-field>` and `<md-outlined-select>`, when focused, show an underlying dark line, even if the primary theme color is set to something else. This patch addresses said issue. 

Here you can take a look at what is going on with the latest version of this library (v2.2.0 at this moment). 

If you look carefully at the focused input in the first screenshot, you'll see that dark line just beneath the label, whereas all other parts of that input are brown-ish.
The second image shows the resulting page after having applied this patch. Here you can see how the dark line is no longer visible and all parts of the input border have the same color.

Before patch | After being patched
------------- | --------------------
![][og]            | ![][patched]


Even though these screenshots were captured on a iOS 18 Simulator, I've seen this issue both on real iOS devices, and previous versions of iOS Simulators. The same issue also occurs on Safari on macOS. 
Moreover, every recent version of `@material/web` seems to be affected by this bug.


@asyncLiz could you take a look at this PR?

*PS: Thanks for the awesome project!*

[og]: https://github.com/user-attachments/assets/0cdda343-c627-4997-83d2-ae37abbe60f2
[patched]: https://github.com/user-attachments/assets/f62163d6-c789-4b13-ace5-ad1b4dec9b2b
