### PR TITLE
Add abstracted props in order to make internal components replaceable for all buttons

### DIFF
--- a/button/internal/button.ts
+++ b/button/internal/button.ts
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import '../../focus/md-focus-ring.js';
-import '../../ripple/ripple.js';
-
 import {html, isServer, LitElement, nothing} from 'lit';
 import {property, query, queryAssignedElements} from 'lit/decorators.js';
 
@@ -25,6 +22,7 @@ import {
   internals,
   mixinElementInternals,
 } from '../../labs/behaviors/element-internals.js';
+import {html as staticHtml, StaticValue} from 'lit/static-html.js';
 
 // Separate variable needed for closure.
 const buttonBaseClass = mixinDelegatesAria(mixinElementInternals(LitElement));
@@ -36,6 +34,10 @@ export abstract class Button extends buttonBaseClass implements FormSubmitter {
   static {
     setupFormSubmitter(Button);
   }
+
+  protected abstract readonly focusRingTag: StaticValue;
+
+  protected abstract readonly rippleTag: StaticValue;
 
   /** @nocollapse */
   static readonly formAssociated = true;
@@ -141,14 +143,17 @@ export abstract class Button extends buttonBaseClass implements FormSubmitter {
     // TODO(b/310046938): due to a limitation in focus ring/ripple, we can't use
     // the same ID for different elements, so we change the ID instead.
     const buttonId = this.href ? 'link' : 'button';
-    return html`
+    return staticHtml`
       ${this.renderElevationOrOutline?.()}
       <div class="background"></div>
-      <md-focus-ring part="focus-ring" for=${buttonId}></md-focus-ring>
-      <md-ripple
+      <${this.focusRingTag}
+        part="focus-ring" for=${buttonId}
+      ></${this.focusRingTag}>
+      <${this.rippleTag}
         part="ripple"
         for=${buttonId}
-        ?disabled="${isRippleDisabled}"></md-ripple>
+        ?disabled="${isRippleDisabled}"
+      ></${this.rippleTag}>
       ${buttonOrLink}
     `;
   }

--- a/button/internal/elevated-button.ts
+++ b/button/internal/elevated-button.ts
@@ -7,13 +7,21 @@
 import '../../elevation/elevation.js';
 
 import {html} from 'lit';
+import {literal} from 'lit/static-html.js';
 
 import {Button} from './button.js';
+
+import '../../focus/md-focus-ring.js';
+import '../../ripple/ripple.js';
 
 /**
  * An elevated button component.
  */
 export class ElevatedButton extends Button {
+  protected readonly focusRingTag = literal`md-focus-ring`;
+
+  protected readonly rippleTag = literal`md-ripple`;
+
   protected override renderElevationOrOutline() {
     return html`<md-elevation part="elevation"></md-elevation>`;
   }

--- a/button/internal/filled-button.ts
+++ b/button/internal/filled-button.ts
@@ -7,13 +7,21 @@
 import '../../elevation/elevation.js';
 
 import {html} from 'lit';
+import {literal} from 'lit/static-html.js';
 
 import {Button} from './button.js';
+
+import '../../focus/md-focus-ring.js';
+import '../../ripple/ripple.js';
 
 /**
  * A filled button component.
  */
 export class FilledButton extends Button {
+  protected readonly focusRingTag = literal`md-focus-ring`;
+
+  protected readonly rippleTag = literal`md-ripple`;
+
   protected override renderElevationOrOutline() {
     return html`<md-elevation part="elevation"></md-elevation>`;
   }

--- a/button/internal/filled-tonal-button.ts
+++ b/button/internal/filled-tonal-button.ts
@@ -7,13 +7,21 @@
 import '../../elevation/elevation.js';
 
 import {html} from 'lit';
+import {literal} from 'lit/static-html.js';
 
 import {Button} from './button.js';
+
+import '../../focus/md-focus-ring.js';
+import '../../ripple/ripple.js';
 
 /**
  * A filled tonal button component.
  */
 export class FilledTonalButton extends Button {
+  protected readonly focusRingTag = literal`md-focus-ring`;
+
+  protected readonly rippleTag = literal`md-ripple`;
+
   protected override renderElevationOrOutline() {
     return html`<md-elevation part="elevation"></md-elevation>`;
   }

--- a/button/internal/outlined-button.ts
+++ b/button/internal/outlined-button.ts
@@ -5,13 +5,21 @@
  */
 
 import {html} from 'lit';
+import {literal} from 'lit/static-html.js';
 
 import {Button} from './button.js';
+
+import '../../focus/md-focus-ring.js';
+import '../../ripple/ripple.js';
 
 /**
  * An outlined button component.
  */
 export class OutlinedButton extends Button {
+  protected readonly focusRingTag = literal`md-focus-ring`;
+
+  protected readonly rippleTag = literal`md-ripple`;
+
   protected override renderElevationOrOutline() {
     return html`<div class="outline"></div>`;
   }

--- a/button/internal/text-button.ts
+++ b/button/internal/text-button.ts
@@ -4,9 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import {literal} from 'lit/static-html.js';
+
 import {Button} from './button.js';
+
+import '../../focus/md-focus-ring.js';
+import '../../ripple/ripple.js';
 
 /**
  * A text button component.
  */
-export class TextButton extends Button {}
+export class TextButton extends Button {
+  protected readonly focusRingTag = literal`md-focus-ring`;
+
+  protected readonly rippleTag = literal`md-ripple`;
+}

--- a/iconbutton/filled-icon-button.ts
+++ b/iconbutton/filled-icon-button.ts
@@ -6,10 +6,14 @@
 
 import {CSSResultOrNative} from 'lit';
 import {customElement} from 'lit/decorators.js';
+import {literal} from 'lit/static-html.js';
 
 import {styles} from './internal/filled-styles.js';
 import {IconButton} from './internal/icon-button.js';
 import {styles as sharedStyles} from './internal/shared-styles.js';
+
+import '../focus/md-focus-ring.js';
+import '../ripple/ripple.js';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -38,6 +42,10 @@ declare global {
 @customElement('md-filled-icon-button')
 export class MdFilledIconButton extends IconButton {
   static override styles: CSSResultOrNative[] = [sharedStyles, styles];
+
+  protected readonly focusRingTag = literal`md-focus-ring`;
+
+  protected readonly rippleTag = literal`md-ripple`;
 
   protected override getRenderClasses() {
     return {

--- a/iconbutton/filled-tonal-icon-button.ts
+++ b/iconbutton/filled-tonal-icon-button.ts
@@ -6,10 +6,14 @@
 
 import {CSSResultOrNative} from 'lit';
 import {customElement} from 'lit/decorators.js';
+import {literal} from 'lit/static-html.js';
 
 import {styles} from './internal/filled-tonal-styles.js';
 import {IconButton} from './internal/icon-button.js';
 import {styles as sharedStyles} from './internal/shared-styles.js';
+
+import '../focus/md-focus-ring.js';
+import '../ripple/ripple.js';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -38,6 +42,10 @@ declare global {
 @customElement('md-filled-tonal-icon-button')
 export class MdFilledTonalIconButton extends IconButton {
   static override styles: CSSResultOrNative[] = [sharedStyles, styles];
+
+  protected readonly focusRingTag = literal`md-focus-ring`;
+
+  protected readonly rippleTag = literal`md-ripple`;
 
   protected override getRenderClasses() {
     return {

--- a/iconbutton/icon-button.ts
+++ b/iconbutton/icon-button.ts
@@ -6,10 +6,14 @@
 
 import {CSSResultOrNative} from 'lit';
 import {customElement} from 'lit/decorators.js';
+import {literal} from 'lit/static-html.js';
 
 import {IconButton} from './internal/icon-button.js';
 import {styles as sharedStyles} from './internal/shared-styles.js';
 import {styles} from './internal/standard-styles.js';
+
+import '../focus/md-focus-ring.js';
+import '../ripple/ripple.js';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -38,6 +42,10 @@ declare global {
 @customElement('md-icon-button')
 export class MdIconButton extends IconButton {
   static override styles: CSSResultOrNative[] = [sharedStyles, styles];
+
+  protected readonly focusRingTag = literal`md-focus-ring`;
+
+  protected readonly rippleTag = literal`md-ripple`;
 
   protected override getRenderClasses() {
     return {

--- a/iconbutton/internal/icon-button.ts
+++ b/iconbutton/internal/icon-button.ts
@@ -4,13 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import '../../focus/md-focus-ring.js';
-import '../../ripple/ripple.js';
-
 import {html, isServer, LitElement, nothing} from 'lit';
 import {property, state} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
-import {literal, html as staticHtml} from 'lit/static-html.js';
+import {literal, html as staticHtml, StaticValue} from 'lit/static-html.js';
 
 import {ARIAMixinStrict} from '../../internal/aria/aria.js';
 import {mixinDelegatesAria} from '../../internal/aria/delegate.js';
@@ -39,10 +36,14 @@ const iconButtonBaseClass = mixinDelegatesAria(
  * --composed
  * @fires change {Event} Dispatched when a toggle button toggles --bubbles
  */
-export class IconButton extends iconButtonBaseClass implements FormSubmitter {
+export abstract class IconButton extends iconButtonBaseClass implements FormSubmitter {
   static {
     setupFormSubmitter(IconButton);
   }
+
+  protected abstract readonly focusRingTag: StaticValue;
+
+  protected abstract readonly rippleTag: StaticValue;
 
   /** @nocollapse */
   static readonly formAssociated = true;
@@ -221,17 +222,17 @@ export class IconButton extends iconButtonBaseClass implements FormSubmitter {
 
   private renderFocusRing() {
     // TODO(b/310046938): use the same id for both elements
-    return html`<md-focus-ring
+    return staticHtml`<${this.focusRingTag}
       part="focus-ring"
-      for=${this.href ? 'link' : 'button'}></md-focus-ring>`;
+      for=${this.href ? 'link' : 'button'}></${this.focusRingTag}>`;
   }
 
   private renderRipple() {
     const isRippleDisabled = !this.href && (this.disabled || this.softDisabled);
     // TODO(b/310046938): use the same id for both elements
-    return html`<md-ripple
+    return staticHtml`<${this.rippleTag}
       for=${this.href ? 'link' : nothing}
-      ?disabled="${isRippleDisabled}"></md-ripple>`;
+      ?disabled="${isRippleDisabled}"></${this.rippleTag}>`;
   }
 
   override connectedCallback() {

--- a/iconbutton/outlined-icon-button.ts
+++ b/iconbutton/outlined-icon-button.ts
@@ -6,10 +6,14 @@
 
 import {CSSResultOrNative} from 'lit';
 import {customElement} from 'lit/decorators.js';
+import {literal} from 'lit/static-html.js';
 
 import {IconButton} from './internal/icon-button.js';
 import {styles} from './internal/outlined-styles.js';
 import {styles as sharedStyles} from './internal/shared-styles.js';
+
+import '../focus/md-focus-ring.js';
+import '../ripple/ripple.js';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -38,6 +42,10 @@ declare global {
 @customElement('md-outlined-icon-button')
 export class MdOutlinedIconButton extends IconButton {
   static override styles: CSSResultOrNative[] = [sharedStyles, styles];
+
+  protected readonly focusRingTag = literal`md-focus-ring`;
+
+  protected readonly rippleTag = literal`md-ripple`;
 
   protected override getRenderClasses() {
     return {


### PR DESCRIPTION
So this idea is based on the interal select component class:

https://github.com/material-components/material-web/blob/main/select/internal/select.ts#L219
https://github.com/material-components/material-web/blob/main/select/internal/select.ts#L391-L417

with this feature it was possible for our team to extend this class and replace it with our customized filled field component;  similar to what we see in the filled select component:
 
https://github.com/material-components/material-web/blob/main/select/internal/filled-select.ts#L15

Our team faces right now the issue that the internal focus ring/ripple component is not switching its colors correctly when we switch the theme because these are wrapped around our own version of md-button/md-icon-button. Right now we apply hacky css based solutions in order to color them correctly.

With this PR we are able to customize all material web button components better, similar to select.