### PR TITLE
Prevent label from overflowing on buttons

### DIFF
--- a/button/internal/_shared.scss
+++ b/button/internal/_shared.scss
@@ -23,6 +23,8 @@
     gap: 8px;
     // min-height instead of height so that label can wrap and expand height
     min-height: var(--_container-height);
+    // max-width set to 100% to prevent label from overflowing
+    max-width: 100%;
     outline: none;
     // Add extra space between label and the edge for if the label text wraps.
     // The padding added should be relative to the height of the container and


### PR DESCRIPTION
When using (very) long labels on buttons, they will overflow rather than wrap or cut off the text. It seems that in https://github.com/material-components/material-web/commit/5d964adcf9df7cfc4cc0b6108e378e6bc6b330fd effort has been made to truncate labels in such cases, however I still experience some issues with longer labels on buttons without explicit width.

The simplest fix I could manage to find was adding a simple `max-width: 100%` to the button, to ensure it wraps by default. If there's a more subtle way to fix this, I'm all ears!

Demonstrating example:
```html
<!DOCTYPE html>
<html>
<head>
  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
  <script type="importmap">
  {
    "imports": {
      "@material/web/": "https://esm.run/@material/web/"
    }
  }
  </script>
  <script type="module">
  import '@material/web/all.js';
  import {styles as typescaleStyles} from '@material/web/typography/md-typescale-styles.js';

  document.adoptedStyleSheets.push(typescaleStyles.styleSheet);
  </script>
</head>
<body>
  <p><md-filled-button>Some very long text on a button that will not fit on small screen sizes</md-text-button></p>
  <p><md-filled-button style="max-width: 100%;">Some very long text on a button that will not fit on small screen sizes</md-text-button></p>
  <style>
  md-text-button {
    font-size: 24px;
  }
  </style>
</body>
</html>
```

![{646DADA2-140B-40C2-8819-B537C79324F8}](https://github.com/user-attachments/assets/3f914ac5-b7f1-431a-a0ee-d37e5ad63b6a)
