### PR TITLE
fix(catalog): add hyphen to md-elevated-button attribute

### DIFF
--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -107,7 +107,7 @@ payment'"
     </style>
     <div class="wrapper">
       <div>
-        <md-elevated-button hasicon>
+        <md-elevated-button has-icon>
           <md-icon slot="icon">add</md-icon>
           Elevated
         </md-elevated-button>


### PR DESCRIPTION
<details open>
  <summary><b><em>Actual button/internal/button.ts hasIcon property declaration:</em></b></summary>

  ```typescript
      /**
       * Whether to display the icon or not.
       */
     @property({type: Boolean, attribute: 'has-icon', reflect: true}) hasIcon = false;
  ```
</details>

While the code for the button with an icon in the catalog displays correctly, I believe that checking the code in the stories or Dev Tools might mislead users. This has been my experience.