### PR TITLE
feat(button,chips,iconbutton): add download filename support for links

### DIFF
--- a/button/internal/button.ts
+++ b/button/internal/button.ts
@@ -72,7 +72,7 @@ export abstract class Button extends buttonBaseClass implements FormSubmitter {
    * If not specified, the browser will determine a filename. 
    * This is only applicable when the button is used as a link (`href` is set).
    */
-  @property() downloadFilename = '';
+  @property() download = '';
 
   /**
    * Where to display the linked `href` URL for a link button. Common options
@@ -191,7 +191,7 @@ export abstract class Button extends buttonBaseClass implements FormSubmitter {
       aria-haspopup="${ariaHasPopup || nothing}"
       aria-expanded="${ariaExpanded || nothing}"
       href=${this.href}
-      download=${this.downloadFilename || nothing}
+      download=${this.download || nothing}
       target=${this.target || nothing}
       >${this.renderContent()}
     </a>`;

--- a/button/internal/button.ts
+++ b/button/internal/button.ts
@@ -68,6 +68,13 @@ export abstract class Button extends buttonBaseClass implements FormSubmitter {
   @property() href = '';
 
   /**
+   * The filename to use when downloading the linked resource. 
+   * If not specified, the browser will determine a filename. 
+   * This is only applicable when the button is used as a link (`href` is set).
+   */
+  @property() downloadFilename = '';
+
+  /**
    * Where to display the linked `href` URL for a link button. Common options
    * include `_blank` to open in a new tab.
    */
@@ -184,6 +191,7 @@ export abstract class Button extends buttonBaseClass implements FormSubmitter {
       aria-haspopup="${ariaHasPopup || nothing}"
       aria-expanded="${ariaExpanded || nothing}"
       href=${this.href}
+      download=${this.downloadFilename || nothing}
       target=${this.target || nothing}
       >${this.renderContent()}
     </a>`;

--- a/chips/internal/assist-chip.ts
+++ b/chips/internal/assist-chip.ts
@@ -19,6 +19,12 @@ import {Chip} from './chip.js';
 export class AssistChip extends Chip {
   @property({type: Boolean}) elevated = false;
   @property() href = '';
+  /**
+   * The filename to use when downloading the linked resource. 
+   * If not specified, the browser will determine a filename. 
+   * This is only applicable when the chip is used as a link (`href` is set).
+   */
+  @property() download = '';
   @property() target: '_blank' | '_parent' | '_self' | '_top' | '' = '';
 
   protected get primaryId() {
@@ -49,6 +55,7 @@ export class AssistChip extends Chip {
           id="link"
           aria-label=${ariaLabel || nothing}
           href=${this.href}
+          download=${this.download || nothing}
           target=${this.target || nothing}
           >${content}</a
         >

--- a/iconbutton/internal/icon-button.ts
+++ b/iconbutton/internal/icon-button.ts
@@ -80,6 +80,13 @@ export class IconButton extends iconButtonBaseClass implements FormSubmitter {
   @property() href = '';
 
   /**
+   * The filename to use when downloading the linked resource. 
+   * If not specified, the browser will determine a filename. 
+   * This is only applicable when the icon button is used as a link (`href` is set).
+   */
+  @property() download = '';
+
+  /**
    * Sets the underlying `HTMLAnchorElement`'s `target` attribute.
    */
   @property() target: LinkTarget | '' = '';
@@ -191,6 +198,7 @@ export class IconButton extends iconButtonBaseClass implements FormSubmitter {
         class="link"
         id="link"
         href="${this.href}"
+        download="${this.download || nothing}"
         target="${this.target || nothing}"
         aria-label="${ariaLabel || nothing}">
         ${this.renderTouchTarget()}


### PR DESCRIPTION
Adds support for specifying a filename when downloading a file using a link button.
Example usage:

```html
<md-filled-tonal-button href="#" download="example-file.pdf">
  Download File (PDF, 1.5 MB)
</md-filled-tonal-button>
```