### PR TITLE
feat(textfield): add showPicker method

### DIFF
--- a/textfield/internal/text-field.ts
+++ b/textfield/internal/text-field.ts
@@ -459,6 +459,23 @@ export abstract class TextField extends textFieldBaseClass {
   }
 
   /**
+   * Shows the browser picker for an input element of type "date", "time", etc.
+   *
+   * For a full list of supported types, see:
+   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/showPicker#browser_compatibility
+   *
+   * https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/showPicker
+   */
+  showPicker() {
+    const input = this.getInput();
+    if (!input) {
+      return;
+    }
+
+    input.showPicker();
+  }
+
+  /**
    * Decrements the value of a numeric type text field by `step` or `n` `step`
    * number of times.
    *


### PR DESCRIPTION
This PR adds a new method to the `TextField` class in `textfield/internal/text-field.ts` to support calling of the `showPicker` method, which allows the browser picker to be shown for input elements of type "date", "time", etc.