### PR TITLE
fix(menu): output menu item theme values

### DIFF
--- a/menu/internal/menuitem/_menu-item.scss
+++ b/menu/internal/menuitem/_menu-item.scss
@@ -24,7 +24,7 @@
       @error 'Token `#{$token}` is not a supported token.';
     }
 
-    @if $value and list.index($supported-tokens, $token) == null {
+    @if $value {
       --md-menu-item-#{$token}: #{$value};
     }
   }


### PR DESCRIPTION
This follows other implementations (eg. [`menu/internal/_menu.scss#L27`](https://github.com/material-components/material-web/blob/c72650fa2e1810c5497ed2e1c19e46ca6cb185d3/menu/internal/_menu.scss#L27)).

Fixes https://github.com/material-components/material-web/issues/5789.