### PR TITLE
fix(chip): set input chip leading-space to 12px

### DIFF
--- a/tokens/_md-comp-input-chip.scss
+++ b/tokens/_md-comp-input-chip.scss
@@ -130,7 +130,7 @@ $_default: (
   $new-tokens: map.merge(
     shape.get-new-logical-shape-tokens($tokens, 'container-shape'),
     (
-      'leading-space': if($exclude-hardcoded-values, null, 16px),
+      'leading-space': if($exclude-hardcoded-values, null, 12px),
       'trailing-space': if($exclude-hardcoded-values, null, 16px),
       'icon-label-space': if($exclude-hardcoded-values, null, 8px),
       'with-leading-icon-leading-space':


### PR DESCRIPTION
According to the design doc, leading padding should be 12dp[1] rather than 16.

Fixes: material-components/material-web#5784

[1] https://m3.material.io/components/chips/specs#1dcff1cb-22f5-41da-809e-6c85b467cff1