### PR TITLE
fix(ripple): ripple not triggered by HTMLLabelElement

### DIFF
--- a/checkbox/internal/_checkbox.scss
+++ b/checkbox/internal/_checkbox.scss
@@ -149,6 +149,8 @@ $_checkmark-bottom-left: 7px, -14px;
 
   // Ripple
 
+  @include ripple.controls;
+
   md-ripple {
     border-radius: map.get($tokens, 'state-layer-shape');
     height: map.get($tokens, 'state-layer-size');

--- a/radio/internal/_radio.scss
+++ b/radio/internal/_radio.scss
@@ -33,6 +33,8 @@ $_md-sys-motion: tokens.md-sys-motion-values();
 @mixin styles() {
   $tokens: tokens.md-comp-radio-values();
 
+  @include ripple.controls;
+
   @layer {
     :host {
       display: inline-flex;

--- a/ripple/_ripple.scss
+++ b/ripple/_ripple.scss
@@ -4,3 +4,4 @@
 //
 
 @forward './internal/ripple' show theme;
+@forward './internal/ripple' show controls;

--- a/ripple/internal/_ripple.scss
+++ b/ripple/internal/_ripple.scss
@@ -11,15 +11,24 @@
 @use '../../tokens';
 // go/keep-sorted end
 
+@mixin ripple-hover($tokens) {
+  background-color: map.get($tokens, 'hover-color');
+  opacity: map.get($tokens, 'hover-opacity');
+}
+
+@mixin ripple-active($tokens) {
+  opacity: map.get($tokens, 'pressed-opacity');
+  transition-duration: 105ms;
+}
+
 @mixin controls {
+  $tokens: tokens.md-comp-ripple-values();
   :host(:hover) md-ripple {
-    background-color: var(--md-ripple-hover-color);
-    opacity: var(--md-ripple-hover-opacity);
+    @include ripple-hover($tokens);
   }
 
   :host(:active) md-ripple {
-    opacity: var(--md-ripple-pressed-opacity);
-    transition-duration: 105ms;
+    @include ripple-active($tokens);
   }
 }
 
@@ -92,13 +101,11 @@
   }
 
   .hovered::before {
-    background-color: map.get($tokens, 'hover-color');
-    opacity: map.get($tokens, 'hover-opacity');
+    @include ripple-hover($tokens);
   }
 
   .pressed::after {
     // press ripple fade-in
-    opacity: map.get($tokens, 'pressed-opacity');
-    transition-duration: 105ms;
+    @include ripple-active($tokens);
   }
 }

--- a/ripple/internal/_ripple.scss
+++ b/ripple/internal/_ripple.scss
@@ -11,6 +11,18 @@
 @use '../../tokens';
 // go/keep-sorted end
 
+@mixin controls {
+  :host(:hover) md-ripple {
+    background-color: var(--md-ripple-hover-color);
+    opacity: var(--md-ripple-hover-opacity);
+  }
+
+  :host(:active) md-ripple {
+    opacity: var(--md-ripple-pressed-opacity);
+    transition-duration: 105ms;
+  }
+}
+
 @mixin theme($tokens) {
   $supported-tokens: tokens.$md-comp-ripple-supported-tokens;
   @each $token, $value in $tokens {

--- a/ripple/internal/_ripple.scss
+++ b/ripple/internal/_ripple.scss
@@ -21,13 +21,14 @@
   transition-duration: 105ms;
 }
 
+// controls for elements that might be triggered via a HTMLLabelElement
 @mixin controls {
   $tokens: tokens.md-comp-ripple-values();
-  :host(:hover) md-ripple {
+  :host(:hover) md-ripple::part(surface)::before {
     @include ripple-hover($tokens);
   }
 
-  :host(:active) md-ripple {
+  :host(:active) md-ripple::part(surface)::after {
     @include ripple-active($tokens);
   }
 }

--- a/switch/internal/_switch.scss
+++ b/switch/internal/_switch.scss
@@ -10,6 +10,7 @@
 // go/keep-sorted start
 @use '../../focus/focus-ring';
 @use '../../tokens';
+@use '../../ripple/ripple';
 @use './handle';
 @use './icon';
 @use './track';
@@ -29,6 +30,8 @@
 }
 
 @mixin styles() {
+  @include ripple.controls;
+
   $tokens: tokens.md-comp-switch-values();
 
   @layer styles, hcm;


### PR DESCRIPTION
adds
- part(surface) in ripple
- ripple.controls mixin which can be used by (form)Elements that can be assosiated whith an HTMLLabelElement.
- controls included by:
  - radio
  - checkbox
  - switch

fixes: #5803