### PR TITLE
fix(catalog): hide body if dsd-pending

### DIFF
--- a/catalog/site/_includes/default.html
+++ b/catalog/site/_includes/default.html
@@ -33,6 +33,12 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined&display=swap"
     />
+    <!-- dsd-pending hides body until the polyfill has run on browsers that do not support DSD -->
+    <style>
+      body[dsd-pending] {
+        display: none;
+      }
+    </style>
     <!-- If JS is disabled just show the contents without the polyfill -->
     <noscript
       ><style>
@@ -44,7 +50,6 @@
     <!-- Allows sub-templates to insert into the head -->
     {% block head %}{% endblock %}
   </head>
-  <!-- dsd-pending hides body until the polyfill has run on browsers that do not support DSD -->
   <body dsd-pending>
     <!-- Inlines the declarative shadow dom polyfill for FF since it's performance sensitive -->
     {% inlinejs "ssr-utils/dsd-polyfill.js" %}


### PR DESCRIPTION
# Description

Incorporating a CSS rule to mitigate [First Contentful Paint](https://web.dev/articles/fcp) (FCP) layout shifts on non-DSD-native user agents. This explicitly leverages the `dsd-pending` attribute, which is added in the default template and subsequently removed post-DOM hydration by the `src/ssr-utils/dsd-polyfill.ts`. This ensures a controlled initial rendering state, preventing unstyled or unhydrated content from momentarily disrupting visual stability.
