### PR TITLE
fix(catalog): hydrate CSR component pages

### DIFF
--- a/catalog/site/_includes/layouts/components.html
+++ b/catalog/site/_includes/layouts/components.html
@@ -12,11 +12,13 @@
 
 {% block content %}
 {% if not ssrOnly %}
-<!-- Loads page JS on idle callback at src/hydration-entrypoints/components/md-file-name.ts -->
-<lit-island
-    on:idle
-    import="/js/hydration-entrypoints{{ page.filePathStem }}.js">
-</lit-island>
+  <!-- Loads page JS on idle callback at src/hydration-entrypoints/components/md-file-name.ts -->
+  <lit-island
+      on:idle
+      import="/js/hydration-entrypoints{{ page.filePathStem }}.js">
+    {{ content | mdMarkdown | safe }}
+  </lit-island>
+{% else %}
+  {{ content | mdMarkdown | safe }}
 {% endif %}
-{{ content | mdMarkdown | safe }}
 {% endblock %}


### PR DESCRIPTION
# Description
This `{% if not ssrOnly %}` ... `{% else %}` ... `{% endif %}` is a conditional statement that checks if a variable named `ssrOnly` is `false`.
If it is `false` then the JavaScript is loaded and hydrated onto the components nested inside on an idle callback via the `<lit-island>` utility.

Essentially, a `<lit-island>` tag is a wrapper or a container designed to encapsulate other Lit components and control when and how they are hydrated (become interactive) on the client side.

This PR fixes the layout structure to provide hydration or not depending on the `ssrOnly` attribute.

