### PR TITLE
fix(radio): move root assignment to mirror hostDisconnected

### DIFF
--- a/radio/internal/single-selection-controller.ts
+++ b/radio/internal/single-selection-controller.ts
@@ -77,11 +77,6 @@ export class SingleSelectionController implements ReactiveController {
     this.host.addEventListener('keydown', this.handleKeyDown);
     this.host.addEventListener('focusin', this.handleFocusIn);
     this.host.addEventListener('focusout', this.handleFocusOut);
-    if (this.host.checked) {
-      // Uncheck other siblings when attached if already checked. This mimics
-      // native <input type="radio"> behavior.
-      this.uncheckSiblings();
-    }
 
     // Update siblings after a microtask to allow other synchronous connected
     // callbacks to settle before triggering additional Lit updates. This avoids
@@ -90,6 +85,12 @@ export class SingleSelectionController implements ReactiveController {
     queueMicrotask(() => {
       // Update for the newly added host.
       this.root = this.host.getRootNode() as ParentNode;
+      if (this.host.checked) {
+        // Uncheck other siblings when attached if already checked. This mimics
+        // native <input type="radio"> behavior.
+        this.uncheckSiblings();
+      }
+
       this.updateTabIndices();
     });
   }


### PR DESCRIPTION
Fixes a regression caused by 688ab3c where calling hostConnected / hostDisconnected in rapid succession can cause root to become null. This regression can be experienced in Angular where content projection causes it to call hostConnected → hostDisconnected → hostConnected in rapid succession. I'm not familiar enough with Angular's internals to know why it needs to do this multiple times in a row but regardless the two lifecycles should be mirrored.