### PR TITLE
docs: rename undefined acronym MWC to Material Web for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ that helps build beautiful and accessible web applications. It uses
 open-source design system.
 
 **Note:
-[MWC is in maintenance mode pending new maintainers](https://github.com/material-components/material-web/discussions/5642).**
+[Material Web is in maintenance mode pending new maintainers](https://github.com/material-components/material-web/discussions/5642).**
 
 ## Resources
 


### PR DESCRIPTION
The README uses the acronym 'MWC' without defining it. Replaced it with 'Material Web' to match the rest of the documentation and improve clarity for new users.