### PR TITLE
docs: add the attribute name for `disabled` in slider docs

### DIFF
--- a/docs/components/slider.md
+++ b/docs/components/slider.md
@@ -185,7 +185,7 @@ Token                              | Default value
 | `ticks` | `ticks` | `boolean` | `false` | Whether or not to show tick marks. |
 | `labeled` | `labeled` | `boolean` | `false` | Whether or not to show a value label when activated. |
 | `range` | `range` | `boolean` | `false` | Whether or not to show a value range. When false, the slider displays a slideable handle for the value property; when true, it displays slideable handles for the valueStart and valueEnd properties. |
-| `disabled` |  | `boolean` | `undefined` |  |
+| `disabled` | `disabled` | `boolean` | `undefined` |  |
 | `name` |  | `string` | `undefined` |  |
 | `nameStart` |  | `string` | `undefined` |  |
 | `nameEnd` |  | `string` | `undefined` |  |


### PR DESCRIPTION
Currently in the docs, the table row doesn't list the attribute name of `disabled`, implying that it's not an attribute. By toggling the `disabled` option and inspecting the source at https://material-web.dev/components/slider/stories/, I see that the `disabled` attribute is actually shown in the element.