### PR TITLE
fix(radio): dispatch input event on keyboard navigation

### DIFF
--- a/radio/internal/single-selection-controller.ts
+++ b/radio/internal/single-selection-controller.ts
@@ -232,12 +232,17 @@ export class SingleSelectionController implements ReactiveController {
         }
       }
 
-      // The next sibling should be checked, focused and dispatch a change event
+      // The next sibling should be checked, focused and dispatch input and
+      // change events since the change is triggered by a user action.
+      // This matches native <input type="radio"> behavior.
       nextSibling.checked = true;
       nextSibling.tabIndex = 0;
       nextSibling.focus();
-      // Fire a change event since the change is triggered by a user action.
-      // This matches native <input type="radio"> behavior.
+      // Fire input before change, matching native <input type="radio"> order.
+      // input is composed so it crosses shadow DOM boundaries like native.
+      nextSibling.dispatchEvent(
+        new InputEvent('input', {bubbles: true, composed: true}),
+      );
       nextSibling.dispatchEvent(new Event('change', {bubbles: true}));
 
       break;

--- a/radio/radio_test.ts
+++ b/radio/radio_test.ts
@@ -183,6 +183,20 @@ describe('<md-radio>', () => {
       expect(changeHandler).toHaveBeenCalledTimes(1);
     });
 
+    it('dispatches an input event on user navigation', async () => {
+      const {harnesses, root} = await setupTest(radioGroupPreSelected);
+      const inputHandler = jasmine.createSpy('inputHandler');
+      root.addEventListener('input', inputHandler);
+      const [, a2] = harnesses;
+      expect(a2.element.checked)
+        .withContext('default checked radio')
+        .toBeTrue();
+
+      await simulateKeyDown(a2.element, 'ArrowRight');
+
+      expect(inputHandler).toHaveBeenCalledTimes(1);
+    });
+
     it('Using arrow right on the last radio should select the first radio in that group', async () => {
       const {harnesses} = await setupTest(radioGroupPreSelected);
       const [a1, a2, a3, b1] = harnesses;


### PR DESCRIPTION
## Problem

Fixes #5447

Native `<input type="radio">` fires both `input` **and** `change` events when a radio button is selected via arrow key navigation. `<md-radio>` only dispatches `change`, which means:

- React users miss keyboard selections because React's `onChange` maps to the DOM `input` event, not `change`
- Any listener specifically watching for `input` events is silently skipped on keyboard navigation

## Fix

In `SingleSelectionController.handleKeyDown`, fire an `InputEvent('input', { bubbles: true, composed: true })` before the existing `change` event, matching native `<input type="radio">` order and behavior:

- `composed: true` so the event crosses shadow DOM boundaries (same as native)
- `input` fires before `change` (same order as native)

A new test `dispatches an input event on user navigation` is added alongside the existing `dispatched a change event on user navigation` test.

## Testing

```
// Before fix – input handler never called on ArrowRight
radio.addEventListener('input', () => console.log('input fired'));

// After fix – fires on both click and arrow key navigation
```