### PR TITLE
fix(dialog): layer scrim above selected tabs

### DIFF
--- a/dialog/dialog_test.ts
+++ b/dialog/dialog_test.ts
@@ -96,7 +96,7 @@ describe('<md-dialog>', () => {
       expect(dialogElement.open).toBeFalse();
     });
 
-    it('renders scrim above selected tabs', async () => {
+    it('renders scrim with selected tabs isolated', async () => {
       const {harness, root, scrimElement} = await setupTest();
       const tabs = document.createElement('md-tabs');
       const selectedTab = document.createElement('md-primary-tab');
@@ -109,11 +109,12 @@ describe('<md-dialog>', () => {
 
       await harness.element.show();
       const scrimZIndex = Number(getComputedStyle(scrimElement).zIndex);
+      const tabsIsolation = getComputedStyle(tabs).isolation;
       const selectedTabZIndex = Number(getComputedStyle(selectedTab).zIndex);
       expect(selectedTab.active).withContext('selected tab active').toBeTrue();
-      expect(scrimZIndex)
-        .withContext('scrim above selected tab')
-        .toBeGreaterThan(selectedTabZIndex);
+      expect(scrimZIndex).withContext('scrim z-index').toBe(1);
+      expect(selectedTabZIndex).withContext('selected tab z-index').toBe(1);
+      expect(tabsIsolation).withContext('tabs isolate child z-index').toBe('isolate');
     });
 
     it('fires open/close events', async () => {

--- a/dialog/dialog_test.ts
+++ b/dialog/dialog_test.ts
@@ -9,6 +9,9 @@ import {html} from 'lit';
 import {Environment} from '../testing/environment.js';
 import {createTokenTests} from '../testing/tokens.js';
 
+import '../tabs/primary-tab.js';
+import '../tabs/tabs.js';
+
 import {MdDialog} from './dialog.js';
 import {DialogHarness} from './harness.js';
 
@@ -41,6 +44,11 @@ describe('<md-dialog>', () => {
       throw new Error('Failed to query rendered <dialog>');
     }
 
+    const scrimElement = dialog.shadowRoot?.querySelector<HTMLElement>('.scrim');
+    if (!scrimElement) {
+      throw new Error('Failed to query rendered scrim.');
+    }
+
     const contentElement = root.querySelector<HTMLElement>('[slot=content]');
     if (!contentElement) {
       throw new Error('Failed to query rendered content.');
@@ -51,7 +59,14 @@ describe('<md-dialog>', () => {
       throw new Error('Failed to query rendered autofocus element.');
     }
 
-    return {harness, root, dialogElement, contentElement, focusElement};
+    return {
+      harness,
+      root,
+      dialogElement,
+      scrimElement,
+      contentElement,
+      focusElement,
+    };
   }
 
   describe('.styles', () => {
@@ -79,6 +94,26 @@ describe('<md-dialog>', () => {
       expect(dialogElement.open).toBeTrue();
       await harness.element.close();
       expect(dialogElement.open).toBeFalse();
+    });
+
+    it('renders scrim above selected tabs', async () => {
+      const {harness, root, scrimElement} = await setupTest();
+      const tabs = document.createElement('md-tabs');
+      const selectedTab = document.createElement('md-primary-tab');
+      const otherTab = document.createElement('md-primary-tab');
+      selectedTab.textContent = 'A';
+      otherTab.textContent = 'B';
+      tabs.append(selectedTab, otherTab);
+      root.append(tabs);
+      await env.waitForStability();
+
+      await harness.element.show();
+      const scrimZIndex = Number(getComputedStyle(scrimElement).zIndex);
+      const selectedTabZIndex = Number(getComputedStyle(selectedTab).zIndex);
+      expect(selectedTab.active).withContext('selected tab active').toBeTrue();
+      expect(scrimZIndex)
+        .withContext('scrim above selected tab')
+        .toBeGreaterThan(selectedTabZIndex);
     });
 
     it('fires open/close events', async () => {

--- a/dialog/internal/_dialog.scss
+++ b/dialog/internal/_dialog.scss
@@ -78,7 +78,8 @@
     opacity: 32%;
     pointer-events: none;
     position: fixed;
-    z-index: 1;
+    // Keep the scrim above component internals such as selected tabs.
+    z-index: 2;
   }
 
   :host([open]) .scrim {

--- a/dialog/internal/_dialog.scss
+++ b/dialog/internal/_dialog.scss
@@ -78,8 +78,7 @@
     opacity: 32%;
     pointer-events: none;
     position: fixed;
-    // Keep the scrim above component internals such as selected tabs.
-    z-index: 2;
+    z-index: 1;
   }
 
   :host([open]) .scrim {

--- a/tabs/internal/_tabs.scss
+++ b/tabs/internal/_tabs.scss
@@ -10,6 +10,7 @@
     box-sizing: border-box;
     display: flex;
     flex-direction: column;
+    isolation: isolate;
     overflow: auto;
     scroll-behavior: smooth;
     scrollbar-width: none;


### PR DESCRIPTION
## Problem

When an `md-dialog` is rendered before `md-tabs`, the dialog scrim can appear behind the selected tab. Both the dialog scrim and selected tab currently use `z-index: 1`, so DOM order can let the selected tab paint above the scrim.

## Change

Add `isolation: isolate` to the `<md-tabs>` host so selected tab internals stay inside the tabs stacking context instead of leaking above sibling components such as dialog scrims.

This keeps the selected tab's existing `z-index: 1` behavior local to tabs and leaves dialog scrim styling, dialog focus behavior, animations, and native `<dialog>` usage unchanged.

## Validation

- `npm ci`
- `npm run build`
- `/Users/jaksen/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/@web/test-runner/dist/bin.js dialog/dialog_test.js tabs/tabs_test.js --config web-test-runner.config.js`
  - `dialog/dialog_test.js` and `tabs/tabs_test.js`: 71 passed, 0 failed
- `git diff --check`

Note: `npx wtr dialog/dialog_test.js --config web-test-runner.config.js` failed before running tests in my local shell under Node 26 with a `yargs` ESM/CJS loader error. The focused browser test above passed using the bundled Node 24 runtime.

## Risk

Low. The change adds a stacking context to the existing tabs host and keeps the selected tab's current `z-index: 1`. The regression test renders an active `md-primary-tab` with a dialog and verifies the tabs host isolates the selected tab stacking layer.

## Out of scope

- Adding a new `<md-scrim>` component
- Switching dialog to native `::backdrop`
- Adding a public z-index token
- Increasing the dialog scrim z-index

## Issue linkage

Closes #4948
