### PR TITLE
fix(textfield): submit forms on Enter

### DIFF
--- a/textfield/internal/text-field.ts
+++ b/textfield/internal/text-field.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {LitElement, PropertyValues, html, nothing} from 'lit';
+import {LitElement, PropertyValues, html, isServer, nothing} from 'lit';
 import {property, query, queryAssignedElements, state} from 'lit/decorators.js';
 import {classMap} from 'lit/directives/class-map.js';
 import {live} from 'lit/directives/live.js';
@@ -15,6 +15,10 @@ import {Field} from '../../field/internal/field.js';
 import {ARIAMixinStrict} from '../../internal/aria/aria.js';
 import {mixinDelegatesAria} from '../../internal/aria/delegate.js';
 import {stringConverter} from '../../internal/controller/string-converter.js';
+import {
+  afterDispatch,
+  setupDispatchHooks,
+} from '../../internal/events/dispatch-hooks.js';
 import {redispatchEvent} from '../../internal/events/redispatch-event.js';
 import {
   createValidator,
@@ -99,6 +103,31 @@ export abstract class TextField extends textFieldBaseClass {
     ...LitElement.shadowRootOptions,
     delegatesFocus: true,
   };
+
+  constructor() {
+    super();
+    if (isServer) {
+      return;
+    }
+
+    setupDispatchHooks(this, 'keydown');
+    this.addEventListener('keydown', (event: KeyboardEvent) => {
+      afterDispatch(event, () => {
+        const ignoreEvent =
+          event.defaultPrevented ||
+          event.key !== 'Enter' ||
+          event.isComposing ||
+          this.disabled ||
+          this.type === 'textarea' ||
+          event.composedPath()[0] !== this.inputOrTextarea;
+        if (ignoreEvent) {
+          return;
+        }
+
+        this.form?.requestSubmit();
+      });
+    });
+  }
 
   /**
    * Gets or sets whether or not the text field is in a visually invalid state.

--- a/textfield/internal/text-field_test.ts
+++ b/textfield/internal/text-field_test.ts
@@ -602,6 +602,37 @@ describe('TextField', () => {
   });
 
   describe('forms', () => {
+    async function setupFormSubmitTest(
+      template = html`<md-test-text-field></md-test-text-field>`,
+    ) {
+      const root = env.render(html`<form>${template}</form>`);
+      const form = root.querySelector('form');
+      if (!form) {
+        throw new Error('Could not query rendered <form>.');
+      }
+
+      const testElement = root.querySelector('md-test-text-field');
+      if (!testElement) {
+        throw new Error('Could not query rendered <md-test-text-field>.');
+      }
+
+      await env.waitForStability();
+
+      return {
+        form,
+        testElement,
+        harness: new TextFieldHarness(testElement),
+      };
+    }
+
+    function createSubmitListener() {
+      return jasmine.createSpy('submitListener').and.callFake(
+        (event: SubmitEvent) => {
+          event.preventDefault();
+        },
+      );
+    }
+
     createFormTests({
       queryControl: (root) => root.querySelector('md-test-text-field'),
       valueTests: [
@@ -691,6 +722,75 @@ describe('TextField', () => {
           },
         },
       ],
+    });
+
+    it('should submit form on Enter', async () => {
+      const {form, harness} = await setupFormSubmitTest(
+        html`<md-test-text-field
+          name="input"
+          value="Value"></md-test-text-field>`,
+      );
+      const submitListener = createSubmitListener();
+      form.addEventListener('submit', submitListener);
+
+      await harness.keypress('Enter');
+      await env.waitForStability();
+
+      expect(submitListener).toHaveBeenCalledTimes(1);
+      const formData = new FormData(form);
+      expect(formData.get('input')).toBe('Value');
+    });
+
+    it('should not submit form on Enter when keydown is canceled', async () => {
+      const {form, testElement, harness} = await setupFormSubmitTest(
+        html`<md-test-text-field name="input"></md-test-text-field>`,
+      );
+      const submitListener = createSubmitListener();
+      form.addEventListener('submit', submitListener);
+      testElement.addEventListener(
+        'keydown',
+        (event) => {
+          event.preventDefault();
+        },
+        {once: true},
+      );
+
+      await harness.keypress('Enter');
+      await env.waitForStability();
+
+      expect(submitListener).not.toHaveBeenCalled();
+    });
+
+    it('should not submit form on Enter for textareas', async () => {
+      const {form, harness} = await setupFormSubmitTest(
+        html`<md-test-text-field type="textarea"></md-test-text-field>`,
+      );
+      const submitListener = createSubmitListener();
+      form.addEventListener('submit', submitListener);
+
+      await harness.keypress('Enter');
+      await env.waitForStability();
+
+      expect(submitListener).not.toHaveBeenCalled();
+    });
+
+    it('should not submit form on Enter from slotted trailing content', async () => {
+      const {form, testElement} = await setupFormSubmitTest(
+        html`<md-test-text-field name="input"></md-test-text-field>`,
+      );
+      render(html`<button slot="trailing-icon">Search</button>`, testElement);
+      const button = testElement.querySelector('button');
+      if (!button) {
+        throw new Error('Could not query rendered trailing button.');
+      }
+
+      const submitListener = createSubmitListener();
+      form.addEventListener('submit', submitListener);
+
+      await new Harness(button).keypress('Enter');
+      await env.waitForStability();
+
+      expect(submitListener).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Problem

Pressing Enter in an `md-*text-field` does not currently submit the associated form, so users have to add their own key handler and call form submission manually.

## Change

This adds a focused `keydown` handler to the shared text field base class. After the Enter key event finishes dispatching, the text field calls `requestSubmit()` on its associated form when the event originated from the internal input.

The handler intentionally skips canceled events, IME composition, disabled text fields, textarea text fields, and Enter events from slotted trailing content.

## Validation

- `git diff --check`
- `PATH=/Users/jaksen/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npm run build:ts`
- `PATH=/Users/jaksen/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node node_modules/@web/test-runner/dist/bin.js --config web-test-runner.config.js --files textfield/internal/text-field_test.js --static-logging`
  - Chromium: `textfield/internal/text-field_test.js`, 88 passed, 0 failed

## Risk

This changes keyboard submission behavior for text fields inside forms. The guard conditions are meant to preserve existing behavior for textarea input, canceled key events, disabled controls, composition events, and slotted trailing actions.

## Out of scope

This does not change button submission, form submitter behavior, textarea Enter behavior, or slotted icon button activation behavior.

## Issue linkage

Closes #4182
